### PR TITLE
fix a list handling bug

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -489,10 +489,11 @@ class ChildPart {
 
 			// create or update a root for every item.
 			let i = 0
+			let end = this.#span._start
 			for (const item of value) {
 				// @ts-expect-error -- WeakMap lookups of non-objects always return undefined, which is fine
 				const key = keys.get(item) ?? item
-				let root = (this.#roots[i] ??= Root.insertAfter(this.#span._end))
+				let root = (this.#roots[i] ??= Root.insertAfter(end))
 
 				if (key !== undefined && root._key !== key) {
 					const j = this.#roots.findIndex(r => r._key === key)
@@ -518,8 +519,7 @@ class ChildPart {
 				}
 
 				root.render(item)
-				this.#span._end = root._span._end
-
+				end = root._span._end
 				i++
 			}
 
@@ -531,6 +531,7 @@ class ChildPart {
 				root._span._deleteContents()
 			}
 
+			this.#span._end = end
 			if (endsWereEqual) this.#parentSpan._end = this.#span._end
 
 			return

--- a/test/lists.test.ts
+++ b/test/lists.test.ts
@@ -148,6 +148,19 @@ describe('lists', () => {
 		root.render(wrapped)
 		expect(el.innerHTML).toBe('[]')
 	})
+
+	it('full then empty then full', () => {
+		const { root, el } = setup()
+
+		root.render([1])
+		expect(el.innerHTML).toBe('1')
+
+		root.render([])
+		expect(el.innerHTML).toBe('')
+
+		root.render([2])
+		expect(el.innerHTML).toBe('2')
+	})
 })
 
 describe('list reordering', () => {


### PR DESCRIPTION
the span would be wrong when a list is rendered with an item, then without, then with again.