### PR TITLE
remove special attribute syntax

### DIFF
--- a/examples/todomvc/main.js
+++ b/examples/todomvc/main.js
@@ -37,15 +37,15 @@ class TodoItem {
 					<input
 						class="toggle"
 						type="checkbox"
-						.checked=${this.completed}
-						@change=${e => {
+						checked=${this.completed}
+						onchange=${e => {
 							e.preventDefault()
 							this.completed = e.target.checked
 							invalidate(this.app)
 						}}
 					/>
 					<label
-						@dblclick=${() => {
+						ondblclick=${() => {
 							this.editing = true
 							invalidate(this)
 						}}
@@ -53,7 +53,7 @@ class TodoItem {
 					>
 					<button
 						class="destroy"
-						@click=${() => {
+						onclick=${() => {
 							this.app.remove(this.id)
 							invalidate(this.app)
 						}}
@@ -67,7 +67,7 @@ class TodoItem {
 									value=${this.title}
 									${autofocus}
 									${autoselect}
-									@blur=${e => {
+									onblur=${e => {
 										const value = e.target.value.trim()
 										if (value) {
 											this.title = value
@@ -75,7 +75,7 @@ class TodoItem {
 											invalidate(this)
 										}
 									}}
-									@keydown=${e => {
+									onkeydown=${e => {
 										if (e.key === 'Enter') {
 											const value = e.target.value.trim()
 											if (value) {
@@ -115,7 +115,7 @@ class App {
 					class="new-todo"
 					placeholder="What needs to be done?"
 					autofocus
-					@keydown=${event => {
+					onkeydown=${event => {
 						if (event.key === 'Enter') {
 							const value = event.target.value.trim()
 							if (value) {
@@ -135,8 +135,8 @@ class App {
 									class="toggle-all"
 									id="toggle-all"
 									type="checkbox"
-									.checked=${activeCount === 0}
-									@change=${e => {
+									checked=${activeCount === 0}
+									onchange=${e => {
 										for (const todo of this.todos) todo.completed = e.target.checked
 										invalidate(this)
 									}}
@@ -165,7 +165,7 @@ class App {
 											<a
 												href="#"
 												${classes}=${this.filter === filter && 'selected'}
-												@click=${() => {
+												onclick=${() => {
 													this.filter = filter
 													invalidate(this)
 												}}

--- a/examples/todomvc/main.js
+++ b/examples/todomvc/main.js
@@ -1,10 +1,12 @@
 import { createRoot, html, invalidate } from 'dhtml'
 
-function classes(node, value) {
-	const values = value.filter(Boolean)
-	node.classList.add(...values)
-	return () => {
-		node.classList.remove(...values)
+function classes(...args) {
+	const classes = args.flatMap(a => (a ? a.split(' ') : []))
+	return node => {
+		node.classList.add(...classes)
+		return () => {
+			node.classList.remove(...classes)
+		}
 	}
 }
 
@@ -22,7 +24,7 @@ class TodoItem {
 
 	render() {
 		return html`
-			<li ${classes}=${[this.completed && 'completed', this.editing && 'editing']}>
+			<li ${classes(this.completed && 'completed', this.editing && 'editing')}>
 				<div class="view">
 					<input
 						class="toggle"
@@ -154,7 +156,7 @@ class App {
 										html`<li>
 											<a
 												href="#"
-												${classes}=${this.filter === filter && 'selected'}
+												${classes(this.filter === filter && 'selected')}
 												onclick=${() => {
 													this.filter = filter
 													invalidate(this)

--- a/examples/todomvc/main.js
+++ b/examples/todomvc/main.js
@@ -1,20 +1,10 @@
 import { createRoot, html, invalidate } from 'dhtml'
 
 function classes(node, value) {
-	let prev = new Set()
-	update(value)
-	return { update, detach: update }
-	function update(value = []) {
-		if (!Array.isArray(value)) value = [value]
-		const added = new Set(value.filter(Boolean).flatMap(x => x.split(' ')))
-		for (const name of added) {
-			prev.delete(name)
-			node.classList.add(name)
-		}
-		for (const name of prev) {
-			node.classList.remove(name)
-		}
-		prev = added
+	const values = value.filter(Boolean)
+	node.classList.add(...values)
+	return () => {
+		node.classList.remove(...values)
 	}
 }
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ const app = {
   render() {
     return html\`
       <button
-        @click=\${() => {
+        onclick=\${() => {
           this.i++
           invalidate(this)
         }}
@@ -44,7 +44,7 @@ createRoot(document.body).render(app)`
 							</header>
 							<pre>${codePre}<a href=${url}>${url}</a>${codePost}</pre>
 							<button
-								@click=${() => {
+								onclick=${() => {
 									this.i++
 									invalidate(this)
 								}}

--- a/src/html.d.ts
+++ b/src/html.d.ts
@@ -16,4 +16,4 @@ export interface Root {
 
 export function createRoot(node: Node): Root
 
-export function attr(name: string): Directive<string | boolean | null | undefined>
+export function attr(name: string, value: string | boolean | null | undefined): Directive

--- a/src/html.d.ts
+++ b/src/html.d.ts
@@ -1,6 +1,6 @@
-import type { BoundTemplateInstance, Cleanup, CustomPart, Displayable, Key, Renderable } from './types.ts'
+import type { BoundTemplateInstance, Cleanup, Directive, Displayable, Key, Renderable } from './types.ts'
 
-export { CustomPart, Displayable, Renderable }
+export { Directive, Displayable, Renderable }
 
 export function html(statics: TemplateStringsArray, ...dynamics: unknown[]): BoundTemplateInstance
 export function keyed<T extends Displayable & object>(value: T, key: Key): T
@@ -16,4 +16,4 @@ export interface Root {
 
 export function createRoot(node: Node): Root
 
-export function attr(name: string): CustomPart<string | boolean | null | undefined>
+export function attr(name: string): Directive<string | boolean | null | undefined>

--- a/src/html.d.ts
+++ b/src/html.d.ts
@@ -15,3 +15,5 @@ export interface Root {
 }
 
 export function createRoot(node: Node): Root
+
+export function attr(name: string): CustomPartConstructor<string | boolean | null | undefined>

--- a/src/html.d.ts
+++ b/src/html.d.ts
@@ -1,11 +1,11 @@
-import type { BoundTemplateInstance, CustomPartConstructor, Displayable, Key, Renderable } from './types.ts'
+import type { BoundTemplateInstance, Cleanup, CustomPart, Displayable, Key, Renderable } from './types.ts'
 
-export { CustomPartConstructor as CustomPart, Displayable, Renderable }
+export { CustomPart, Displayable, Renderable }
 
 export function html(statics: TemplateStringsArray, ...dynamics: unknown[]): BoundTemplateInstance
 export function keyed<T extends Displayable & object>(value: T, key: Key): T
 export function invalidate(renderable: Renderable): Promise<void>
-export function onMount(renderable: Renderable, callback: () => void | (() => void)): void
+export function onMount(renderable: Renderable, callback: () => Cleanup): void
 export function onUnmount(renderable: Renderable, callback: () => void): void
 export function getParentNode(renderable: Renderable): Node
 
@@ -16,4 +16,4 @@ export interface Root {
 
 export function createRoot(node: Node): Root
 
-export function attr(name: string): CustomPartConstructor<string | boolean | null | undefined>
+export function attr(name: string): CustomPart<string | boolean | null | undefined>

--- a/src/html.js
+++ b/src/html.js
@@ -1,7 +1,6 @@
 /** @import {
 	Cleanup,
 	CompiledTemplate,
-	CustomPart,
 	Displayable,
 	Key,
 	Part,
@@ -292,7 +291,7 @@ function compileTemplate(statics) {
 
 				let match = DYNAMIC_WHOLE.exec(name)
 				if (match !== null) {
-					// custom part:
+					// directive:
 					toRemove.push(name)
 					const idx = parseInt(match[1])
 					match = DYNAMIC_WHOLE.exec(value)

--- a/src/html.js
+++ b/src/html.js
@@ -704,3 +704,18 @@ class CustomPartValue extends CustomPartBase {
 		super.update()
 	}
 }
+
+export function attr(name) {
+	return (node, value) => {
+		update(value)
+		return { update, detach }
+		function update(value) {
+			if (typeof value === 'boolean') node.toggleAttribute(name, value)
+			else if (value == null) node.removeAttribute(name)
+			else node.setAttribute(name, value)
+		}
+		function detach() {
+			node.removeAttribute(name)
+		}
+	}
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface Part {
 }
 
 export type Cleanup = (() => void) | void | undefined | null
-export type Directive<T = unknown> = (node: Element, value: T) => Cleanup
+export type Directive = (node: Element) => Cleanup
 
 export interface CompiledTemplate {
 	_content: DocumentFragment

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,13 +28,8 @@ export interface Part {
 	detach(): void
 }
 
-export interface CustomPartInstance<T> {
-	update?(value: T): void
-	detach?(): void
-}
-export type CustomPartConstructor<T = unknown> =
-	| ((node: Element, value: T) => CustomPartInstance<T>)
-	| (new (node: Element, value: T) => CustomPartInstance<T>)
+export type Cleanup = (() => void) | void | undefined | null
+export type CustomPart<T = unknown> = (node: Element, value: T) => Cleanup
 
 export interface CompiledTemplate {
 	_content: DocumentFragment

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface Part {
 }
 
 export type Cleanup = (() => void) | void | undefined | null
-export type CustomPart<T = unknown> = (node: Element, value: T) => Cleanup
+export type Directive<T = unknown> = (node: Element, value: T) => Cleanup
 
 export interface CompiledTemplate {
 	_content: DocumentFragment

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -31,18 +31,40 @@ describe('attributes', () => {
 	it('supports property attributes', () => {
 		const { root, el } = setup()
 
-		root.render(html`<h1 class-name=${'foo'}>Hello, world!</h1>`)
-		expect(el.querySelector('h1')).toHaveClass('foo')
-	})
-
-	it('supports booleans', () => {
-		const { root, el } = setup()
-
 		root.render(html`<details open=${true}></details>`)
 		expect(el.querySelector('details')!.open).toBe(true)
 
 		root.render(html`<details open=${false}></details>`)
 		expect(el.querySelector('details')!.open).toBe(false)
+	})
+
+	it('guesses the case of properties', () => {
+		const { root, el } = setup()
+
+		const innerHTML = '<h1>Hello, world!</h1>'
+
+		root.render(html`<div innerhtml=${innerHTML}></div>`)
+		expect(el.querySelector('div')!.innerHTML).toBe(innerHTML)
+
+		root.render(html`<span innerHTML=${innerHTML}></span>`)
+		expect(el.querySelector('span')!.innerHTML).toBe(innerHTML)
+	})
+
+	it('treats class/for specially', () => {
+		const { root, el } = setup()
+
+		root.render(html`<h1 class=${'foo'}>Hello, world!</h1>`)
+		expect(el.querySelector('h1')).toHaveClass('foo')
+
+		root.render(html`<label for=${'foo'}>Hello, world!</label>`)
+		expect(el.querySelector('label')).toHaveAttribute('for', 'foo')
+	})
+
+	it('handles data attributes', () => {
+		const { root, el } = setup()
+
+		root.render(html`<h1 data-foo=${'bar'}>Hello, world!</h1>`)
+		expect(el.querySelector('h1')).toHaveAttribute('data-foo', 'bar')
 	})
 
 	it('supports events', () => {

--- a/test/attributes.test.ts
+++ b/test/attributes.test.ts
@@ -7,7 +7,7 @@ describe('attributes', () => {
 		const { root, el } = setup()
 
 		root.render(html`<h1 style=${'color: red'}>Hello, world!</h1>`)
-		expect(el.querySelector('h1')).toHaveAttribute('style', 'color: red')
+		expect(el.querySelector('h1')).toHaveAttribute('style', 'color: red;')
 	})
 
 	it('can toggle attributes', () => {
@@ -31,25 +31,18 @@ describe('attributes', () => {
 	it('supports property attributes', () => {
 		const { root, el } = setup()
 
-		root.render(html`<h1 .class-name=${'foo'}>Hello, world!</h1>`)
+		root.render(html`<h1 class-name=${'foo'}>Hello, world!</h1>`)
 		expect(el.querySelector('h1')).toHaveClass('foo')
-	})
-
-	it('throws on property attributes without dynamic values', { skip: import.meta.env.PROD }, () => {
-		const { root } = setup()
-
-		expect(() => {
-			root.render(html`<h1 .class-name="bar">This also</h1>`)
-		}).toThrowErrorMatchingInlineSnapshot(
-			`[Error: static properties are not supported, please wrap the value of .class-name in \${...}]`,
-		)
 	})
 
 	it('supports booleans', () => {
 		const { root, el } = setup()
 
 		root.render(html`<details open=${true}></details>`)
-		expect(el.querySelector('details')?.open).toBe(true)
+		expect(el.querySelector('details')!.open).toBe(true)
+
+		root.render(html`<details open=${false}></details>`)
+		expect(el.querySelector('details')!.open).toBe(false)
 	})
 
 	it('supports events', () => {
@@ -58,7 +51,7 @@ describe('attributes', () => {
 		let clicks = 0
 		root.render(html`
 			<button
-				@click=${() => {
+				onclick=${() => {
 					clicks++
 				}}
 			>
@@ -76,7 +69,7 @@ describe('attributes', () => {
 	it('supports event handlers that change', () => {
 		const { root, el } = setup()
 
-		const template = (handler: (() => void) | null) => html`<input @blur=${handler}>Click me</input>`
+		const template = (handler: (() => void) | null) => html`<input onblur=${handler}>Click me</input>`
 
 		const handler = vi.fn()
 		root.render(template(handler))

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -113,21 +113,6 @@ describe('basic', () => {
 })
 
 describe('errors', () => {
-	it('throws on non-function event handlers', { skip: import.meta.env.PROD }, () => {
-		const { root, el } = setup()
-
-		let thrown
-		try {
-			root.render(html`<button @click=${123}></button>`)
-		} catch (error) {
-			thrown = error as Error
-		}
-
-		expect(el.innerHTML).toBe('<button></button>')
-		expect(thrown).toBeInstanceOf(Error)
-		expect(thrown!.message).toMatch(/expected a function/i)
-	})
-
 	it('throws cleanly', () => {
 		const { root, el } = setup()
 

--- a/test/custom-elements.test.ts
+++ b/test/custom-elements.test.ts
@@ -23,7 +23,7 @@ describe('custom elements', () => {
 	it('correctly instantiates custom elements', () => {
 		const { root, el } = setup()
 
-		root.render(html`<custom-element .thing=${'hello'}></custom-element>`)
+		root.render(html`<custom-element thing=${'hello'}></custom-element>`)
 		expect(el.innerHTML).toBe(`<custom-element>inside custom element</custom-element>`)
 
 		const customElement = el.querySelector('custom-element') as CustomElement

--- a/test/custom-parts.test.ts
+++ b/test/custom-parts.test.ts
@@ -1,4 +1,4 @@
-import { html, type CustomPart } from 'dhtml'
+import { attr, html, type CustomPart } from 'dhtml'
 import { describe, expect, it } from 'vitest'
 import { setup } from './setup'
 
@@ -192,5 +192,37 @@ describe('custom parts', () => {
 		expect(detached).toBe(false)
 		root.render(null)
 		expect(detached).toBe(true)
+	})
+})
+
+describe('attr', () => {
+	it('works', () => {
+		const { root, el } = setup()
+
+		const template = (value: string | null) => html`
+			<input id="attr-works-input"></input>
+			<label ${attr('for')}=${value}>Hello, world!</label>
+		`
+
+		root.render(template('attr-works-input'))
+		expect(el.querySelector('label')).toHaveProperty('htmlFor', 'attr-works-input')
+
+		root.render(template('updated'))
+		expect(el.querySelector('label')).toHaveProperty('htmlFor', 'updated')
+
+		root.render(template(null))
+		expect(el.querySelector('label')).toHaveProperty('htmlFor', '')
+	})
+
+	it('supports booleans', () => {
+		const { root, el } = setup()
+
+		const template = (value: boolean) => html`<input ${attr('disabled')}=${value} />`
+
+		root.render(template(true))
+		expect(el.querySelector('input')).toHaveProperty('disabled', true)
+
+		root.render(template(false))
+		expect(el.querySelector('input')).toHaveProperty('disabled', false)
 	})
 })

--- a/test/custom-parts.test.ts
+++ b/test/custom-parts.test.ts
@@ -1,131 +1,23 @@
 import { attr, html, type CustomPart } from 'dhtml'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { setup } from './setup'
 
 describe('custom parts', () => {
-	it('classes', () => {
-		const { root, el } = setup()
-
-		class Redifier {
-			#node
-			constructor(node: Element) {
-				if (!(node instanceof HTMLElement)) throw new Error('expected HTMLElement')
-				this.#node = node
-				node.style.color = 'red'
-			}
-			update() {
-				throw new Error('should never get here')
-			}
-			detach() {
-				this.#node.style.color = ''
-			}
-		}
-		class Flipper {
-			#node
-			constructor(node: Element) {
-				if (!(node instanceof HTMLElement)) throw new Error('expected HTMLElement')
-				this.#node = node
-				node.style.transform = 'scaleX(-1)'
-			}
-			update() {
-				throw new Error('should never get here')
-			}
-			detach() {
-				this.#node.style.transform = ''
-			}
-		}
-
-		const template = (Part: CustomPart | null) => html`<div ${Part}>Hello, world!</div>`
-
-		root.render(template(Redifier))
-		const div = el.firstChild as HTMLElement
-		expect(div.nodeName).toBe('DIV')
-		expect(div.style.cssText).toBe('color: red;')
-
-		root.render(template(Flipper))
-		expect(div.style.cssText).toBe('transform: scaleX(-1);')
-
-		root.render(template(null))
-		expect(div.style.cssText).toBe('')
-
-		root.render(null)
-	})
-
-	it('classes with values', () => {
-		const { root, el } = setup()
-
-		let init = 0
-		let detached = false
-
-		class Classes {
-			#node
-			constructor(node: Element, value: string[]) {
-				init++
-				this.#node = node
-				this.update(value)
-			}
-
-			#prev: Set<string> | undefined
-			update(value: string[]) {
-				const added = new Set(value)
-				for (const name of added) {
-					this.#prev?.delete(name)
-					this.#node.classList.add(name)
-				}
-				for (const name of this.#prev ?? []) {
-					this.#node.classList.remove(name)
-				}
-				this.#prev = added
-			}
-
-			detach() {
-				this.update([])
-				detached = true
-			}
-		}
-
-		const template = (value: string[]) => html`<div ${Classes}=${value}>Hello, world!</div>`
-
-		root.render(template(['a', 'b']))
-		const div = el.firstChild as Element
-		expect(div.tagName).toBe('DIV')
-		expect(div.className).toBe('a b')
-
-		root.render(template(['c', 'd']))
-		expect(div.className).toBe('c d')
-
-		expect(init).toBe(1) // should only be constructed once
-
-		expect(detached).toBe(false)
-		root.render(null)
-		expect(detached).toBe(true)
-	})
-
 	it('functions', () => {
 		const { root, el } = setup()
 
 		const redifier: CustomPart = node => {
 			if (!(node instanceof HTMLElement)) throw new Error('expected HTMLElement')
 			node.style.color = 'red'
-			return {
-				update() {
-					throw new Error('should never get here')
-				},
-				detach() {
-					node.style.color = ''
-				},
+			return () => {
+				node.style.color = ''
 			}
 		}
 		const flipper: CustomPart = node => {
 			if (!(node instanceof HTMLElement)) throw new Error('expected HTMLElement')
 			node.style.transform = 'scaleX(-1)'
-			return {
-				update() {
-					throw new Error('should never get here')
-				},
-				detach() {
-					node.style.transform = ''
-				},
+			return () => {
+				node.style.transform = ''
 			}
 		}
 
@@ -148,50 +40,28 @@ describe('custom parts', () => {
 	it('functions with values', () => {
 		const { root, el } = setup()
 
-		let init = 0
-		let detached = false
-
-		const classes: CustomPart<string[]> = (node, value) => {
-			init++
-			let prev: Set<string> | undefined
-			update(value)
-
-			return {
-				update,
-				detach() {
-					update([])
-					detached = true
-				},
+		const classes: CustomPart<string[]> = vi.fn((node, value) => {
+			const values = value.filter(Boolean)
+			node.classList.add(...values)
+			return () => {
+				node.classList.remove(...values)
 			}
+		})
 
-			function update(value: string[]) {
-				const added = new Set(value)
-				for (const name of added) {
-					prev?.delete(name)
-					node.classList.add(name)
-				}
-				for (const name of prev ?? []) {
-					node.classList.remove(name)
-				}
-				prev = added
-			}
-		}
-
-		const template = (value: string[]) => html`<div ${classes}=${value}>Hello, world!</div>`
+		const template = (value: string[]) => html`<div class="foo" ${classes}=${value}>Hello, world!</div>`
 
 		root.render(template(['a', 'b']))
 		const div = el.firstChild as HTMLElement
 		expect(div.tagName).toBe('DIV')
-		expect(div.className).toBe('a b')
+		expect(div.className).toBe('foo a b')
 
 		root.render(template(['c', 'd']))
-		expect(div.className).toBe('c d')
+		expect(div.className).toBe('foo c d')
 
-		expect(init).toBe(1) // should only be constructed once
+		expect(classes).toHaveBeenCalledTimes(2)
 
-		expect(detached).toBe(false)
-		root.render(null)
-		expect(detached).toBe(true)
+		root.render(template([]))
+		expect(div.className).toBe('foo')
 	})
 })
 

--- a/test/directives.test.ts
+++ b/test/directives.test.ts
@@ -1,5 +1,5 @@
 import { attr, html, type Directive } from 'dhtml'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { setup } from './setup'
 
 describe('directives', () => {
@@ -40,15 +40,17 @@ describe('directives', () => {
 	it('functions with values', () => {
 		const { root, el } = setup()
 
-		const classes: Directive<string[]> = vi.fn((node, value) => {
+		function classes(value: string[]): Directive {
 			const values = value.filter(Boolean)
-			node.classList.add(...values)
-			return () => {
-				node.classList.remove(...values)
+			return node => {
+				node.classList.add(...values)
+				return () => {
+					node.classList.remove(...values)
+				}
 			}
-		})
+		}
 
-		const template = (value: string[]) => html`<div class="foo" ${classes}=${value}>Hello, world!</div>`
+		const template = (c: string[]) => html`<div class="foo" ${classes(c)}>Hello, world!</div>`
 
 		root.render(template(['a', 'b']))
 		const div = el.firstChild as HTMLElement
@@ -57,8 +59,6 @@ describe('directives', () => {
 
 		root.render(template(['c', 'd']))
 		expect(div.className).toBe('foo c d')
-
-		expect(classes).toHaveBeenCalledTimes(2)
 
 		root.render(template([]))
 		expect(div.className).toBe('foo')
@@ -71,7 +71,7 @@ describe('attr', () => {
 
 		const template = (value: string | null) => html`
 			<input id="attr-works-input"></input>
-			<label ${attr('for')}=${value}>Hello, world!</label>
+			<label ${attr('for', value)}>Hello, world!</label>
 		`
 
 		root.render(template('attr-works-input'))
@@ -87,7 +87,7 @@ describe('attr', () => {
 	it('supports booleans', () => {
 		const { root, el } = setup()
 
-		const template = (value: boolean) => html`<input ${attr('disabled')}=${value} />`
+		const template = (value: boolean) => html`<input ${attr('disabled', value)} />`
 
 		root.render(template(true))
 		expect(el.querySelector('input')).toHaveProperty('disabled', true)

--- a/test/directives.test.ts
+++ b/test/directives.test.ts
@@ -1,19 +1,19 @@
-import { attr, html, type CustomPart } from 'dhtml'
+import { attr, html, type Directive } from 'dhtml'
 import { describe, expect, it, vi } from 'vitest'
 import { setup } from './setup'
 
-describe('custom parts', () => {
+describe('directives', () => {
 	it('functions', () => {
 		const { root, el } = setup()
 
-		const redifier: CustomPart = node => {
+		const redifier: Directive = node => {
 			if (!(node instanceof HTMLElement)) throw new Error('expected HTMLElement')
 			node.style.color = 'red'
 			return () => {
 				node.style.color = ''
 			}
 		}
-		const flipper: CustomPart = node => {
+		const flipper: Directive = node => {
 			if (!(node instanceof HTMLElement)) throw new Error('expected HTMLElement')
 			node.style.transform = 'scaleX(-1)'
 			return () => {
@@ -21,7 +21,7 @@ describe('custom parts', () => {
 			}
 		}
 
-		const template = (Part: CustomPart | null) => html`<div ${Part}>Hello, world!</div>`
+		const template = (d: Directive | null) => html`<div ${d}>Hello, world!</div>`
 
 		root.render(template(redifier))
 		const div = el.firstChild as HTMLElement
@@ -40,7 +40,7 @@ describe('custom parts', () => {
 	it('functions with values', () => {
 		const { root, el } = setup()
 
-		const classes: CustomPart<string[]> = vi.fn((node, value) => {
+		const classes: Directive<string[]> = vi.fn((node, value) => {
 			const values = value.filter(Boolean)
 			node.classList.add(...values)
 			return () => {

--- a/test/renderable.test.ts
+++ b/test/renderable.test.ts
@@ -484,7 +484,7 @@ describe('getParentNode', () => {
 				const parent = getParentNode(this)
 
 				expect(parent).toBeInstanceOf(HTMLDivElement)
-				expect((parent as HTMLDivElement).className).toBe('the-app')
+				expect((parent as HTMLDivElement).outerHTML).toMatchInlineSnapshot(`"<div class="the-app"><!----></div>"`)
 				expect(parent.parentNode).toBe(el)
 
 				return null


### PR DESCRIPTION
the rules are simpler now:
if it's static: it's an attribute
if it's dynamic: it's a property

I suspect there are going to be some issues
with className and htmlFor that need to be special-cased,
but otherwise this feels nicer