### PR TITLE
fix a bug related to wrong ChildPart spans

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -205,11 +205,9 @@ class TemplateInstance {
 		span._deleteContents()
 		span._insertNode(doc)
 
-		let prev
 		this._parts = template._parts.map(([dynamicIdx, createPart], elementIdx) => {
-			const part = createPart(prev, span)
+			const part = createPart(span)
 			part.create(nodeByPart[elementIdx], dynamics[dynamicIdx])
-			prev = part
 			return /** @type {const} */ ([dynamicIdx, part])
 		})
 	}
@@ -257,6 +255,9 @@ function compileTemplate(statics) {
 	while ((nextPart < compiled._parts.length || DEV) && walker.nextNode()) {
 		const node = /** @type {Text | Element | Comment} */ (walker.currentNode)
 		if (isText(node)) {
+			// reverse the order because we'll be supplying ChildPart with its index in the parent node.
+			// and if we apply the parts forwards, indicies will be wrong if some prior part renders more than one node.
+			// also reverse it because that's the correct order for splitting.
 			const nodes = [...node.data.matchAll(DYNAMIC_GLOBAL)].reverse().map(match => {
 				node.splitText(match.index + match[0].length)
 				const dyn = new Comment()
@@ -264,16 +265,12 @@ function compileTemplate(statics) {
 				return /** @type {const} */ ([dyn, parseInt(match[1])])
 			})
 
-			// put them back in order, inverting the effect of the reverse above.
-			// not relevant for behavior, but it satisfies the warning when parts are used out of order.
-			nodes.reverse()
-
 			if (nodes.length) {
 				DEV: assert(node.parentNode !== null, 'all text nodes should have a parent node')
 				let siblings = [...node.parentNode.childNodes]
 				for (const [node, idx] of nodes) {
 					const child = siblings.indexOf(node)
-					patch(node.parentNode, idx, (_prev, span) => new ChildPart(child, span))
+					patch(node.parentNode, idx, span => new ChildPart(child, span))
 				}
 			}
 		} else if (DEV && isComment(node)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,6 @@ export type Directive = (node: Element) => Cleanup
 
 export interface CompiledTemplate {
 	_content: DocumentFragment
-	_parts: [idx: number, createPart: (prev: Part, span: Span) => Part][]
+	_parts: [idx: number, createPart: (span: Span) => Part][]
 	_rootParts: number[]
 }

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -110,6 +110,14 @@ describe('basic', () => {
 		expect(el.firstChild).toBeInstanceOf(Text)
 		expect((el.firstChild as Text).data).toBe('abc')
 	})
+
+	it('shifting ChildPart index', () => {
+		const { root, el } = setup()
+
+		root.render(html`${html`A<!--x-->`}B${'C'}`)
+
+		expect(el.innerHTML).toBe('A<!--x-->BC')
+	})
 })
 
 describe('errors', () => {


### PR DESCRIPTION
in
```js
html`${a}|${b}`
```
`a`'s slot's childIndex is 0
`b`'s slot's childIndex is 2

however, where `${a}` results in 2+ nodes:
by the time `${b}` is created, it's no longer at the same index in the parent.

by reversing the order in which the parts are created, the slots are always in the expected position.