### PR TITLE
fix: import shared types from the index

### DIFF
--- a/src/client/controller.ts
+++ b/src/client/controller.ts
@@ -1,4 +1,5 @@
-import { assert, is_renderable, type Displayable, type Renderable } from '../shared.ts'
+import type { Displayable, Renderable } from 'dhtml'
+import { assert, is_renderable } from '../shared.ts'
 import { type Cleanup } from './util.ts'
 
 export type Key = string | number | bigint | boolean | symbol | object | null

--- a/src/client/parts.ts
+++ b/src/client/parts.ts
@@ -1,12 +1,5 @@
-import {
-	assert,
-	is_html,
-	is_iterable,
-	is_renderable,
-	single_part_template,
-	type Displayable,
-	type Renderable,
-} from '../shared.ts'
+import type { Displayable, Renderable } from 'dhtml'
+import { assert, is_html, is_iterable, is_renderable, single_part_template } from '../shared.ts'
 import { controllers, keys, mount_callbacks } from './controller.ts'
 import { create_root, create_root_after, type Root } from './root.ts'
 import { create_span, span_delete_contents, span_extract_contents, span_insert_node, type Span } from './span.ts'

--- a/src/client/root.ts
+++ b/src/client/root.ts
@@ -1,4 +1,5 @@
-import { assert, is_html, single_part_template, type Displayable } from '../shared.ts'
+import type { Displayable } from 'dhtml'
+import { assert, is_html, single_part_template } from '../shared.ts'
 import { compile_template, type CompiledTemplate } from './compiler.ts'
 import type { Key } from './controller.ts'
 import type { Part } from './parts.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,24 @@
-export { html, type Displayable, type Renderable } from './shared.ts'
+import { html_tag } from './shared.ts'
+
+interface ToString {
+	toString(): string
+}
+
+export type Displayable = null | undefined | ToString | Node | Renderable | Iterable<Displayable> | HTML
+export interface Renderable {
+	render(): Displayable
+}
+
+export interface HTML {
+	[html_tag]: true
+	/* @internal */ _statics: TemplateStringsArray
+	/* @internal */ _dynamics: unknown[]
+}
+
+export function html(statics: TemplateStringsArray, ...dynamics: unknown[]): HTML {
+	return {
+		[html_tag]: true,
+		_dynamics: dynamics,
+		_statics: statics,
+	}
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
+import type { Displayable } from 'dhtml'
 import { Tokenizer } from 'htmlparser2'
-import { assert, is_html, is_iterable, is_renderable, single_part_template, type Displayable } from './shared.ts'
+import { assert, is_html, is_iterable, is_renderable, single_part_template } from './shared.ts'
 
 type PartRenderer = (values: unknown[]) => string | Generator<string, void, void>
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,10 +1,7 @@
-interface ToString {
-	toString(): string
-}
+import { html, type Displayable, type HTML, type Renderable } from 'dhtml'
 
-export type Displayable = null | undefined | ToString | Node | Renderable | Iterable<Displayable>
-export interface Renderable {
-	render(): Displayable
+declare global {
+	var __DEV__: boolean
 }
 
 export const is_renderable = (value: unknown): value is Renderable =>
@@ -13,31 +10,12 @@ export const is_renderable = (value: unknown): value is Renderable =>
 export const is_iterable = (value: unknown): value is Iterable<unknown> =>
 	typeof value === 'object' && value !== null && Symbol.iterator in value
 
-declare global {
-	var __DEV__: boolean
-}
-
 export function assert(value: unknown, message?: string): asserts value {
 	if (!__DEV__) return
 	if (!value) throw new Error(message ?? 'assertion failed')
 }
 
-const tag: unique symbol = Symbol()
-
-interface HTML {
-	[tag]: true
-	/* @internal */ _statics: TemplateStringsArray
-	/* @internal */ _dynamics: unknown[]
-}
-
-export const is_html = (value: any): value is HTML => typeof value === 'object' && value !== null && tag in value
-
-export function html(statics: TemplateStringsArray, ...dynamics: unknown[]): HTML {
-	return {
-		[tag]: true,
-		_dynamics: dynamics,
-		_statics: statics,
-	}
-}
+export const html_tag: unique symbol = Symbol()
+export const is_html = (value: any): value is HTML => typeof value === 'object' && value !== null && html_tag in value
 
 export const single_part_template = (part: Displayable): HTML => html`${part}`


### PR DESCRIPTION
this means the dts bundle won't have duplicates, which is important for the unique symbol.