### PR TITLE
migrate to `bun:test`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 23.x
+      - uses: oven-sh/setup-bun@v2
       - run: npm install
-      - run: npm run test:coverage
+      - run: npm run test -- --coverage-reporter=lcov
       - if: always()
         uses: coverallsapp/github-action@v2
         with:
-          file: lcov.info
+          file: coverage/lcov.info
           format: lcov

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 dist
-lcov.info
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 				"@happy-dom/global-registrator": "^17.4.4",
 				"@rollup/plugin-terser": "^0.4.4",
 				"@types/node": "^22.13.11",
+				"bun-types": "^1.2.5",
 				"dhtml": ".",
 				"dts-buddy": "^0.5.5",
 				"htmlparser2": "^10.0.0",
@@ -651,6 +652,16 @@
 				"undici-types": "~6.20.0"
 			}
 		},
+		"node_modules/@types/ws": {
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+			"integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@valibot/to-json-schema": {
 			"version": "1.0.0-rc.0",
 			"resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.0.0-rc.0.tgz",
@@ -676,6 +687,17 @@
 			"version": "1.1.2",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bun-types": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.2.5.tgz",
+			"integrity": "sha512-3oO6LVGGRRKI4kHINx5PIdIgnLRb7l/SprhzqXapmoYkFl5m4j6EvALvbDVuuBFaamB46Ap6HCUxIXNLCGy+tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/ws": "~8.5.10"
+			}
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
 		"build": "node build.js",
 		"format": "prettier --write . --cache",
 		"check": "tsc",
-		"test": "node --no-warnings --test --experimental-test-coverage src/*/tests/*",
-		"test:coverage": "node --no-warnings --test --experimental-test-coverage --test-reporter=spec --test-reporter-destination=stderr --test-reporter=lcov --test-reporter-destination=lcov.info src/*/tests/*",
-		"test:watch": "node --no-warnings --test --watch src/*/tests/*",
-		"test:prod": "npm run build && NODE_ENV=production npm test"
+		"test": "bun test --coverage --define __DEV__=true",
+		"test:watch": "npm test -- --watch",
+		"test:prod": "bun test --define __DEV__=false"
 	},
 	"devDependencies": {
 		"@happy-dom/global-registrator": "^17.4.4",
 		"@rollup/plugin-terser": "^0.4.4",
 		"@types/node": "^22.13.11",
+		"bun-types": "^1.2.5",
 		"dhtml": ".",
 		"dts-buddy": "^0.5.5",
 		"htmlparser2": "^10.0.0",

--- a/src/client/tests/attributes.test.ts
+++ b/src/client/tests/attributes.test.ts
@@ -1,72 +1,73 @@
+import { mock, test } from 'bun:test'
 import { html } from 'dhtml'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
 
-test('regular attributes', (t: TestContext) => {
+test('regular attributes', () => {
 	const { root, el } = setup()
 
 	root.render(html`<h1 style=${'color: red'}>Hello, world!</h1>`)
-	t.assert.strictEqual(el.querySelector('h1')!.getAttribute('style'), 'color: red;')
+	assert.equal(el.querySelector('h1')!.getAttribute('style'), 'color: red;')
 })
 
-test('can toggle attributes', (t: TestContext) => {
+test('can toggle attributes', () => {
 	const { root, el } = setup()
 
 	let hidden: unknown = false
 	const template = () => html`<h1 hidden=${hidden}>Hello, world!</h1>`
 
 	root.render(template())
-	t.assert.ok(!el.querySelector('h1')!.hasAttribute('hidden'))
+	assert(!el.querySelector('h1')!.hasAttribute('hidden'))
 
 	hidden = true
 	root.render(template())
-	t.assert.ok(el.querySelector('h1')!.hasAttribute('hidden'))
+	assert(el.querySelector('h1')!.hasAttribute('hidden'))
 
 	hidden = null
 	root.render(template())
-	t.assert.ok(!el.querySelector('h1')!.hasAttribute('hidden'))
+	assert(!el.querySelector('h1')!.hasAttribute('hidden'))
 })
 
-test('supports property attributes', (t: TestContext) => {
+test('supports property attributes', () => {
 	const { root, el } = setup()
 
 	root.render(html`<details open=${true}></details>`)
-	t.assert.ok(el.querySelector('details')!.open)
+	assert(el.querySelector('details')!.open)
 
 	root.render(html`<details open=${false}></details>`)
-	t.assert.ok(!el.querySelector('details')!.open)
+	assert(!el.querySelector('details')!.open)
 })
 
-test('infers the case of properties', (t: TestContext) => {
+test('infers the case of properties', () => {
 	const { root, el } = setup()
 
 	const innerHTML = '<h1>Hello, world!</h1>'
 
 	root.render(html`<div innerhtml=${innerHTML}></div>`)
-	t.assert.strictEqual(el.querySelector('div')!.innerHTML, innerHTML)
+	assert.equal(el.querySelector('div')!.innerHTML, innerHTML)
 
 	root.render(html`<span innerHTML=${innerHTML}></span>`)
-	t.assert.strictEqual(el.querySelector('span')!.innerHTML, innerHTML)
+	assert.equal(el.querySelector('span')!.innerHTML, innerHTML)
 })
 
-test('treats class/for specially', (t: TestContext) => {
+test('treats class/for specially', () => {
 	const { root, el } = setup()
 
 	root.render(html`<h1 class=${'foo'}>Hello, world!</h1>`)
-	t.assert.strictEqual(el.querySelector('h1')!.className, 'foo')
+	assert.equal(el.querySelector('h1')!.className, 'foo')
 
 	root.render(html`<label for=${'foo'}>Hello, world!</label>`)
-	t.assert.strictEqual(el.querySelector('label')!.htmlFor, 'foo')
+	assert.equal(el.querySelector('label')!.htmlFor, 'foo')
 })
 
-test('handles data attributes', (t: TestContext) => {
+test('handles data attributes', () => {
 	const { root, el } = setup()
 
 	root.render(html`<h1 data-foo=${'bar'}>Hello, world!</h1>`)
-	t.assert.strictEqual(el.querySelector('h1')!.dataset.foo, 'bar')
+	assert.equal(el.querySelector('h1')!.dataset.foo, 'bar')
 })
 
-test('supports events', (t: TestContext) => {
+test('supports events', () => {
 	const { root, el } = setup()
 
 	let clicks = 0
@@ -80,28 +81,28 @@ test('supports events', (t: TestContext) => {
 		</button>
 	`)
 
-	t.assert.strictEqual(clicks, 0)
+	assert.equal(clicks, 0)
 	el.querySelector('button')!.click()
-	t.assert.strictEqual(clicks, 1)
+	assert.equal(clicks, 1)
 	el.querySelector('button')!.click()
-	t.assert.strictEqual(clicks, 2)
+	assert.equal(clicks, 2)
 })
 
-test('supports event handlers that change', (t: TestContext) => {
+test('supports event handlers that change', () => {
 	const { root, el } = setup()
 
-	const template = (handler: (() => void) | null) => html`<input onblur=${handler}>Click me</input>`
+	const template = (handler: ((event: Event) => void) | null) => html`<input onblur=${handler}>Click me</input>`
 
-	const handler = t.mock.fn()
+	const handler = mock((_event: Event) => {})
 	root.render(template(handler))
-	t.assert.strictEqual(handler.mock.callCount(), 0)
+	assert.equal(handler.mock.calls.length, 0)
 
 	const event = new Event('blur')
 	el.querySelector('input')!.dispatchEvent(event)
-	t.assert.strictEqual(handler.mock.callCount(), 1)
-	t.assert.strictEqual(handler.mock.calls[0].arguments[0], event)
+	assert.equal(handler.mock.calls.length, 1)
+	assert.equal(handler.mock.calls[0][0], event)
 
 	root.render(template(null))
 	el.querySelector('input')!.dispatchEvent(new Event('blur'))
-	t.assert.strictEqual(handler.mock.callCount(), 1)
+	assert.equal(handler.mock.calls.length, 1)
 })

--- a/src/client/tests/basic.test.ts
+++ b/src/client/tests/basic.test.ts
@@ -1,124 +1,127 @@
+import { test } from 'bun:test'
 import { html, type Displayable } from 'dhtml'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
 
-test('basic html renders correctly', (t: TestContext) => {
+const dev_test = test.skipIf(!__DEV__)
+
+test('basic html renders correctly', () => {
 	const { root, el } = setup()
 
 	root.render(html`<h1>Hello, world!</h1>`)
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, world!</h1>')
+	assert.equal(el.innerHTML, '<h1>Hello, world!</h1>')
 })
 
-test('inner content renders correctly', (t: TestContext) => {
+test('inner content renders correctly', () => {
 	const { root, el } = setup()
 
 	root.render(html`<h1>${html`Inner content!`}</h1>`)
-	t.assert.strictEqual(el.innerHTML, '<h1>Inner content!</h1>')
+	assert.equal(el.innerHTML, '<h1>Inner content!</h1>')
 })
 
-test('template with number renders correctly', (t: TestContext) => {
+test('template with number renders correctly', () => {
 	const { root, el } = setup()
 
 	const template = (n: number) => html`<h1>Hello, ${n}!</h1>`
 
 	root.render(template(1))
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, 1!</h1>')
+	assert.equal(el.innerHTML, '<h1>Hello, 1!</h1>')
 
 	root.render(template(2))
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, 2!</h1>')
+	assert.equal(el.innerHTML, '<h1>Hello, 2!</h1>')
 })
 
-test('external sibling nodes are not clobbered', (t: TestContext) => {
+test('external sibling nodes are not clobbered', () => {
 	const { root, el } = setup('<div>before</div>')
 
 	root.render(html`<h1>Hello, world!</h1>`)
-	t.assert.strictEqual(el.innerHTML, '<div>before</div><h1>Hello, world!</h1>')
+	assert.equal(el.innerHTML, '<div>before</div><h1>Hello, world!</h1>')
 
 	el.appendChild(document.createElement('div')).textContent = 'after'
-	t.assert.strictEqual(el.innerHTML, '<div>before</div><h1>Hello, world!</h1><div>after</div>')
+	assert.equal(el.innerHTML, '<div>before</div><h1>Hello, world!</h1><div>after</div>')
 
 	root.render(html`<h2>Goodbye, world!</h2>`)
-	t.assert.strictEqual(el.innerHTML, '<div>before</div><h2>Goodbye, world!</h2><div>after</div>')
+	assert.equal(el.innerHTML, '<div>before</div><h2>Goodbye, world!</h2><div>after</div>')
 
 	root.render(html``)
-	t.assert.strictEqual(el.innerHTML, '<div>before</div><div>after</div>')
+	assert.equal(el.innerHTML, '<div>before</div><div>after</div>')
 
 	root.render(html`<h1>Hello, world!</h1>`)
-	t.assert.strictEqual(el.innerHTML, '<div>before</div><h1>Hello, world!</h1><div>after</div>')
+	assert.equal(el.innerHTML, '<div>before</div><h1>Hello, world!</h1><div>after</div>')
 })
 
-test('identity is updated correctly', (t: TestContext) => {
+test('identity is updated correctly', () => {
 	const { root, el } = setup()
 
 	const template = (n: Displayable) => html`<h1>Hello, ${n}!</h1>`
 	const template2 = (n: Displayable) => html`<h1>Hello, ${n}!</h1>`
 
 	root.render(template(1))
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, 1!</h1>')
+	assert.equal(el.innerHTML, '<h1>Hello, 1!</h1>')
 	let h1 = el.children[0]
 	const text = h1.childNodes[1] as Text
-	t.assert.ok(text instanceof Text)
-	t.assert.strictEqual(text.data, '1')
+	assert(text instanceof Text)
+	assert.equal(text.data, '1')
 
 	root.render(template(2))
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, 2!</h1>')
-	t.assert.strictEqual(el.children[0], h1)
-	t.assert.strictEqual(text.data, '2')
-	t.assert.strictEqual(h1.childNodes[1], text)
+	assert.equal(el.innerHTML, '<h1>Hello, 2!</h1>')
+	assert.equal(el.children[0], h1)
+	assert.equal(text.data, '2')
+	assert.equal(h1.childNodes[1], text)
 
 	root.render(template2(3))
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, 3!</h1>')
-	t.assert.notStrictEqual(el.children[0], h1)
+	assert.equal(el.innerHTML, '<h1>Hello, 3!</h1>')
+	assert.notStrictEqual(el.children[0], h1)
 	h1 = el.children[0]
 
 	root.render(template2(template(template('inner'))))
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, <h1>Hello, <h1>Hello, inner!</h1>!</h1>!</h1>')
-	t.assert.strictEqual(el.children[0], h1)
+	assert.equal(el.innerHTML, '<h1>Hello, <h1>Hello, <h1>Hello, inner!</h1>!</h1>!</h1>')
+	assert.equal(el.children[0], h1)
 })
 
-test('basic children render correctly', (t: TestContext) => {
+test('basic children render correctly', () => {
 	const { root, el } = setup()
 
 	root.render(html`<span>${'This is a'}</span> ${html`test`} ${html`test`} ${html`test`}`)
 
-	t.assert.strictEqual(el.innerHTML, '<span>This is a</span> test test test')
+	assert.equal(el.innerHTML, '<span>This is a</span> test test test')
 })
 
-test('nodes can be embedded', (t: TestContext) => {
+test('nodes can be embedded', () => {
 	const { root, el } = setup()
 
 	let node: ParentNode = document.createElement('span')
 
 	root.render(html`<div>${node}</div>`)
-	t.assert.strictEqual(el.innerHTML, '<div><span></span></div>')
-	t.assert.strictEqual(el.children[0].children[0], node)
+	assert.equal(el.innerHTML, '<div><span></span></div>')
+	assert.equal(el.children[0].children[0], node)
 
 	node = document.createDocumentFragment()
 	node.append(document.createElement('h1'), document.createElement('h2'), document.createElement('h3'))
 
 	root.render(html`<div>${node}</div>`)
-	t.assert.strictEqual(el.innerHTML, '<div><h1></h1><h2></h2><h3></h3></div>')
-	t.assert.strictEqual(node.children.length, 0)
+	assert.equal(el.innerHTML, '<div><h1></h1><h2></h2><h3></h3></div>')
+	assert.equal(node.children.length, 0)
 })
 
-test.skip('extra empty text nodes are not added', (t: TestContext) => {
+test.skip('extra empty text nodes are not added', () => {
 	const { root, el } = setup()
 
 	root.render(html`${'abc'}`)
-	t.assert.strictEqual(el.childNodes.length, 1)
-	t.assert.ok(el.firstChild instanceof Text)
-	t.assert.strictEqual((el.firstChild as Text).data, 'abc')
+	assert.equal(el.childNodes.length, 1)
+	assert(el.firstChild instanceof Text)
+	assert.equal((el.firstChild as Text).data, 'abc')
 })
 
-test('ChildPart index shifts correctly', (t: TestContext) => {
+test('ChildPart index shifts correctly', () => {
 	const { root, el } = setup()
 
 	root.render(html`${html`A<!--x-->`}B${'C'}`)
 
-	t.assert.strictEqual(el.innerHTML, 'A<!--x-->BC')
+	assert.equal(el.innerHTML, 'A<!--x-->BC')
 })
 
-test('errors are thrown cleanly', (t: TestContext) => {
+test('errors are thrown cleanly', () => {
 	const { root, el } = setup()
 
 	const oops = new Error('oops')
@@ -134,49 +137,45 @@ test('errors are thrown cleanly', (t: TestContext) => {
 	} catch (error) {
 		thrown = error
 	}
-	t.assert.strictEqual(thrown, oops)
+	assert.equal(thrown, oops)
 
 	// on an error, don't leave any visible artifacts
-	t.assert.strictEqual(el.innerHTML, '<!---->')
+	assert.equal(el.innerHTML, '<!---->')
 })
 
-test('invalid part placement raises error', { skip: process.env.NODE_ENV === 'production' }, (t: TestContext) => {
+dev_test('invalid part placement raises error', () => {
 	const { root, el } = setup()
 
-	t.assert.throws(() => root.render(html`<${'div'}>${'text'}</${'div'}>`), {
+	assert.throws(() => root.render(html`<${'div'}>${'text'}</${'div'}>`), {
 		message: 'expected the same number of dynamics as parts. do you have a ${...} in an unsupported place?',
 	})
-	t.assert.strictEqual(el.innerHTML, '')
+	assert.equal(el.innerHTML, '')
 })
 
-test('parts in comments do not throw', (t: TestContext) => {
+test('parts in comments do not throw', () => {
 	const { root, el } = setup()
 
 	root.render(html`<!-- ${'text'} -->`)
-	t.assert.strictEqual(el.innerHTML, '<!-- dyn-$0$ -->')
+	assert.equal(el.innerHTML, '<!-- dyn-$0$ -->')
 })
 
-test(
-	'manually specifying internal template syntax throws',
-	{ skip: process.env.NODE_ENV === 'production' },
-	(t: TestContext) => {
-		const { root, el } = setup()
+dev_test('manually specifying internal template syntax throws', () => {
+	const { root, el } = setup()
 
-		t.assert.throws(
-			() => {
-				root.render(html`${1} dyn-$0$`)
-			},
-			{ message: 'got more parts than expected' },
-		)
+	assert.throws(
+		() => {
+			root.render(html`${1} dyn-$0$`)
+		},
+		{ message: 'got more parts than expected' },
+	)
 
-		t.assert.strictEqual(el.innerHTML, '')
-	},
-)
+	assert.equal(el.innerHTML, '')
+})
 
-test('syntax close but not exact does not throw', (t: TestContext) => {
+test('syntax close but not exact does not throw', () => {
 	const { root, el } = setup()
 
 	root.render(html`dyn-$${0}1$`)
 
-	t.assert.strictEqual(el.innerHTML, 'dyn-$01$')
+	assert.equal(el.innerHTML, 'dyn-$01$')
 })

--- a/src/client/tests/custom-elements.test.ts
+++ b/src/client/tests/custom-elements.test.ts
@@ -1,6 +1,7 @@
+import { test } from 'bun:test'
 import { html } from 'dhtml'
 import { createRoot } from 'dhtml/client'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
 
 class CustomElement extends HTMLElement {
@@ -20,24 +21,24 @@ class CustomElement extends HTMLElement {
 
 customElements.define('custom-element', CustomElement)
 
-test('custom elements instantiate correctly', (t: TestContext) => {
+test('custom elements instantiate correctly', () => {
 	const { root, el } = setup()
 
 	root.render(html`<custom-element thing=${'hello'}></custom-element>`)
-	t.assert.strictEqual(el.innerHTML, `<custom-element>inside custom element</custom-element>`)
+	assert.equal(el.innerHTML, `<custom-element>inside custom element</custom-element>`)
 
 	const customElement = el.querySelector('custom-element') as CustomElement
-	t.assert.ok(customElement instanceof CustomElement)
-	t.assert.strictEqual(customElement.thing, 'HELLO')
+	assert(customElement instanceof CustomElement)
+	assert.equal(customElement.thing, 'HELLO')
 })
 
-test('content renders into shadow dom', (t: TestContext) => {
+test('content renders into shadow dom', () => {
 	const { el } = setup()
 	const shadowRoot = el.attachShadow({ mode: 'open' })
 
 	const root = createRoot(shadowRoot)
 	root.render(html`<p>hello</p>`)
 
-	t.assert.strictEqual(el.innerHTML, ``)
-	t.assert.strictEqual(shadowRoot.innerHTML, `<p>hello</p>`)
+	assert.equal(el.innerHTML, ``)
+	assert.equal(shadowRoot.innerHTML, `<p>hello</p>`)
 })

--- a/src/client/tests/directives.test.ts
+++ b/src/client/tests/directives.test.ts
@@ -1,9 +1,10 @@
+import { test } from 'bun:test'
 import { html } from 'dhtml'
 import { attr, type Directive } from 'dhtml/client'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
 
-test('directive functions work correctly', (t: TestContext) => {
+test('directive functions work correctly', () => {
 	const { root, el } = setup()
 
 	const redifier: Directive = node => {
@@ -25,19 +26,19 @@ test('directive functions work correctly', (t: TestContext) => {
 
 	root.render(template(redifier))
 	const div = el.firstChild as HTMLElement
-	t.assert.strictEqual(div.tagName, 'DIV')
-	t.assert.strictEqual(div.style.cssText, 'color: red;')
+	assert.equal(div.tagName, 'DIV')
+	assert.equal(div.style.cssText, 'color: red;')
 
 	root.render(template(flipper))
-	t.assert.strictEqual(div.style.cssText, 'transform: scaleX(-1);')
+	assert.equal(div.style.cssText, 'transform: scaleX(-1);')
 
 	root.render(template(null))
-	t.assert.strictEqual(div.style.cssText, '')
+	assert.equal(div.style.cssText, '')
 
 	root.render(null)
 })
 
-test('directive functions with values work correctly', (t: TestContext) => {
+test('directive functions with values work correctly', () => {
 	const { root, el } = setup()
 
 	function classes(value: string[]): Directive {
@@ -54,17 +55,17 @@ test('directive functions with values work correctly', (t: TestContext) => {
 
 	root.render(template(['a', 'b']))
 	const div = el.firstChild as HTMLElement
-	t.assert.strictEqual(div.tagName, 'DIV')
-	t.assert.strictEqual(div.className, 'foo a b')
+	assert.equal(div.tagName, 'DIV')
+	assert.equal(div.className, 'foo a b')
 
 	root.render(template(['c', 'd']))
-	t.assert.strictEqual(div.className, 'foo c d')
+	assert.equal(div.className, 'foo c d')
 
 	root.render(template([]))
-	t.assert.strictEqual(div.className, 'foo')
+	assert.equal(div.className, 'foo')
 })
 
-test('attr directive works correctly', (t: TestContext) => {
+test('attr directive works correctly', () => {
 	const { root, el } = setup()
 
 	const template = (value: string | null) => html`
@@ -73,23 +74,23 @@ test('attr directive works correctly', (t: TestContext) => {
 	`
 
 	root.render(template('attr-works-input'))
-	t.assert.strictEqual(el.querySelector('label')!.htmlFor, 'attr-works-input')
+	assert.equal(el.querySelector('label')!.htmlFor, 'attr-works-input')
 
 	root.render(template('updated'))
-	t.assert.strictEqual(el.querySelector('label')!.htmlFor, 'updated')
+	assert.equal(el.querySelector('label')!.htmlFor, 'updated')
 
 	root.render(template(null))
-	t.assert.strictEqual(el.querySelector('label')!.htmlFor, '')
+	assert.equal(el.querySelector('label')!.htmlFor, '')
 })
 
-test('attr directive supports booleans', (t: TestContext) => {
+test('attr directive supports booleans', () => {
 	const { root, el } = setup()
 
 	const template = (value: boolean) => html`<input ${attr('disabled', value)} />`
 
 	root.render(template(true))
-	t.assert.strictEqual(el.querySelector('input')!.disabled, true)
+	assert.equal(el.querySelector('input')!.disabled, true)
 
 	root.render(template(false))
-	t.assert.strictEqual(el.querySelector('input')!.disabled, false)
+	assert.equal(el.querySelector('input')!.disabled, false)
 })

--- a/src/client/tests/lists.test.ts
+++ b/src/client/tests/lists.test.ts
@@ -1,7 +1,10 @@
+import { test } from 'bun:test'
 import { html, type Displayable } from 'dhtml'
 import { keyed } from 'dhtml/client'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
+
+const dev_test = test.skipIf(!__DEV__)
 
 function shuffle<T>(array: T[]) {
 	for (let i = 0; i < array.length; i++) {
@@ -10,7 +13,7 @@ function shuffle<T>(array: T[]) {
 	}
 }
 
-test('basic list operations work correctly', (t: TestContext) => {
+test('basic list operations work correctly', () => {
 	const { root, el } = setup()
 
 	let items: Displayable[] | null = null
@@ -23,12 +26,12 @@ test('basic list operations work correctly', (t: TestContext) => {
 	`
 
 	root.render(listOfItems())
-	t.assert.strictEqual(el.innerHTML.replace(/\s+/g, ' '), ' <ul> <li>Before</li> <li>After</li> </ul> ')
+	assert.equal(el.innerHTML.replace(/\s+/g, ' '), ' <ul> <li>Before</li> <li>After</li> </ul> ')
 
 	items = [html`<li>Item 1</li>`, html`<li>Item 2</li>`, html`<li>Item 3</li>`]
 
 	root.render(listOfItems())
-	t.assert.strictEqual(
+	assert.equal(
 		el.innerHTML.replace(/\s+/g, ' '),
 		' <ul> <li>Before</li> <li>Item 1</li><li>Item 2</li><li>Item 3</li> <li>After</li> </ul> ',
 	)
@@ -36,136 +39,136 @@ test('basic list operations work correctly', (t: TestContext) => {
 
 	items.push(html`<li>Item 4</li>`)
 	root.render(listOfItems())
-	t.assert.strictEqual(
+	assert.equal(
 		el.innerHTML.replace(/\s+/g, ' '),
 		' <ul> <li>Before</li> <li>Item 1</li><li>Item 2</li><li>Item 3</li><li>Item 4</li> <li>After</li> </ul> ',
 	)
 	const [item1b, item2b, item3b] = el.querySelectorAll('li')
-	t.assert.strictEqual(item1, item1b)
-	t.assert.strictEqual(item2, item2b)
-	t.assert.strictEqual(item3, item3b)
+	assert.equal(item1, item1b)
+	assert.equal(item2, item2b)
+	assert.equal(item3, item3b)
 
 	items.pop()
 	items.pop()
 	root.render(listOfItems())
-	t.assert.strictEqual(
+	assert.equal(
 		el.innerHTML.replace(/\s+/g, ' '),
 		' <ul> <li>Before</li> <li>Item 1</li><li>Item 2</li> <li>After</li> </ul> ',
 	)
 	const [item1c, item2c] = el.querySelectorAll('li')
-	t.assert.strictEqual(item1, item1c)
-	t.assert.strictEqual(item2, item2c)
+	assert.equal(item1, item1c)
+	assert.equal(item2, item2c)
 })
 
-test('pop operation works correctly on lists', (t: TestContext) => {
+test('pop operation works correctly on lists', () => {
 	const { root, el } = setup()
 
 	const items = [html`<p>Item 1</p>`, html`<p>Item 2</p>`, html`<p>Item 3</p>`]
 	const wrapped = html`[${items}]`
 
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
+	assert.equal(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
 	const [item1, item2] = el.children
 
 	items.pop()
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p><p>Item 2</p>]')
-	t.assert.strictEqual(el.children[0], item1)
-	t.assert.strictEqual(el.children[1], item2)
+	assert.equal(el.innerHTML, '[<p>Item 1</p><p>Item 2</p>]')
+	assert.equal(el.children[0], item1)
+	assert.equal(el.children[1], item2)
 
 	items.pop()
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p>]')
-	t.assert.strictEqual(el.children[0], item1)
+	assert.equal(el.innerHTML, '[<p>Item 1</p>]')
+	assert.equal(el.children[0], item1)
 
 	items.pop()
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[]')
+	assert.equal(el.innerHTML, '[]')
 })
 
-test('swap operation works correctly on lists', (t: TestContext) => {
+test('swap operation works correctly on lists', () => {
 	const { root, el } = setup()
 
 	const items = [html`<p>Item 1</p>`, html`<p>Item 2</p>`, html`<p>Item 3</p>`]
 	const wrapped = html`[${items}]`
 
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
+	assert.equal(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
 	const [item1, item2, item3] = el.children
 
 	// swap the first two items
 	;[items[0], items[1]] = [items[1], items[0]]
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 2</p><p>Item 1</p><p>Item 3</p>]')
-	t.assert.strictEqual(el.children[0], item2)
-	t.assert.strictEqual(el.children[1], item1)
-	t.assert.strictEqual(el.children[2], item3)
+	assert.equal(el.innerHTML, '[<p>Item 2</p><p>Item 1</p><p>Item 3</p>]')
+	assert.equal(el.children[0], item2)
+	assert.equal(el.children[1], item1)
+	assert.equal(el.children[2], item3)
 
 	// swap the last two items
 	;[items[1], items[2]] = [items[2], items[1]]
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 2</p><p>Item 3</p><p>Item 1</p>]')
-	t.assert.strictEqual(el.children[0], item2)
-	t.assert.strictEqual(el.children[1], item3)
-	t.assert.strictEqual(el.children[2], item1)
+	assert.equal(el.innerHTML, '[<p>Item 2</p><p>Item 3</p><p>Item 1</p>]')
+	assert.equal(el.children[0], item2)
+	assert.equal(el.children[1], item3)
+	assert.equal(el.children[2], item1)
 
 	// swap the first and last items
 	;[items[0], items[2]] = [items[2], items[0]]
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p><p>Item 3</p><p>Item 2</p>]')
-	t.assert.strictEqual(el.children[0], item1)
-	t.assert.strictEqual(el.children[1], item3)
-	t.assert.strictEqual(el.children[2], item2)
+	assert.equal(el.innerHTML, '[<p>Item 1</p><p>Item 3</p><p>Item 2</p>]')
+	assert.equal(el.children[0], item1)
+	assert.equal(el.children[1], item3)
+	assert.equal(el.children[2], item2)
 
 	// put things back
 	;[items[1], items[2]] = [items[2], items[1]]
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
-	t.assert.strictEqual(el.children[0], item1)
-	t.assert.strictEqual(el.children[1], item2)
-	t.assert.strictEqual(el.children[2], item3)
+	assert.equal(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
+	assert.equal(el.children[0], item1)
+	assert.equal(el.children[1], item2)
+	assert.equal(el.children[2], item3)
 })
 
-test('shift operation works correctly on lists', (t: TestContext) => {
+test('shift operation works correctly on lists', () => {
 	const { root, el } = setup()
 
 	const items = [html`<p>Item 1</p>`, html`<p>Item 2</p>`, html`<p>Item 3</p>`]
 	const wrapped = html`[${items}]`
 
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
+	assert.equal(el.innerHTML, '[<p>Item 1</p><p>Item 2</p><p>Item 3</p>]')
 	const [, item2, item3] = el.children
 
 	items.shift()
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 2</p><p>Item 3</p>]')
-	t.assert.strictEqual(el.children[0], item2)
-	t.assert.strictEqual(el.children[1], item3)
+	assert.equal(el.innerHTML, '[<p>Item 2</p><p>Item 3</p>]')
+	assert.equal(el.children[0], item2)
+	assert.equal(el.children[1], item3)
 
 	items.shift()
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[<p>Item 3</p>]')
-	t.assert.strictEqual(el.children[0], item3)
+	assert.equal(el.innerHTML, '[<p>Item 3</p>]')
+	assert.equal(el.children[0], item3)
 
 	items.shift()
 	root.render(wrapped)
-	t.assert.strictEqual(el.innerHTML, '[]')
+	assert.equal(el.innerHTML, '[]')
 })
 
-test('full then empty then full list renders correctly', (t: TestContext) => {
+test('full then empty then full list renders correctly', () => {
 	const { root, el } = setup()
 
 	root.render([1])
-	t.assert.strictEqual(el.innerHTML, '1')
+	assert.equal(el.innerHTML, '1')
 
 	root.render([])
-	t.assert.strictEqual(el.innerHTML, '')
+	assert.equal(el.innerHTML, '')
 
 	root.render([2])
-	t.assert.strictEqual(el.innerHTML, '2')
+	assert.equal(el.innerHTML, '2')
 })
 
-test('list can disappear when condition changes', (t: TestContext) => {
+test('list can disappear when condition changes', () => {
 	const { root, el } = setup()
 
 	const app = {
@@ -177,81 +180,81 @@ test('list can disappear when condition changes', (t: TestContext) => {
 	}
 
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, '<div>1</div><div>2</div><div>3</div>')
+	assert.equal(el.innerHTML, '<div>1</div><div>2</div><div>3</div>')
 
 	app.show = false
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, '')
+	assert.equal(el.innerHTML, '')
 })
 
-test('unkeyed lists recreate elements when reordered', (t: TestContext) => {
+test('unkeyed lists recreate elements when reordered', () => {
 	const { root, el } = setup()
 
 	const a = () => html`<h1>Item 1</h1>`
 	const b = () => html`<h2>Item 2</h2>`
 
 	root.render([a(), b()])
-	t.assert.strictEqual(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
+	assert.equal(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
 
 	const [h1, h2] = el.children
-	t.assert.strictEqual(h1.tagName, 'H1')
-	t.assert.strictEqual(h2.tagName, 'H2')
+	assert.equal(h1.tagName, 'H1')
+	assert.equal(h2.tagName, 'H2')
 
 	root.render([b(), a()])
-	t.assert.strictEqual(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
+	assert.equal(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
 
 	// visually they should be swapped
-	t.assert.strictEqual(el.children[0].innerHTML, h2.innerHTML)
-	t.assert.strictEqual(el.children[1].innerHTML, h1.innerHTML)
+	assert.equal(el.children[0].innerHTML, h2.innerHTML)
+	assert.equal(el.children[1].innerHTML, h1.innerHTML)
 
 	// but there's no stable identity, so they're recreated
-	t.assert.notStrictEqual(el.children[0], h2)
-	t.assert.notStrictEqual(el.children[1], h1)
+	assert.notStrictEqual(el.children[0], h2)
+	assert.notStrictEqual(el.children[1], h1)
 })
 
-test('explicit keyed lists preserve identity when reordered', (t: TestContext) => {
+test('explicit keyed lists preserve identity when reordered', () => {
 	const { root, el } = setup()
 
 	const a = () => keyed(html`<h1>Item 1</h1>`, 1)
 	const b = () => keyed(html`<h2>Item 2</h2>`, 2)
 
 	root.render([a(), b()])
-	t.assert.strictEqual(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
+	assert.equal(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
 
 	const [h1, h2] = el.children
-	t.assert.strictEqual(h1.tagName, 'H1')
-	t.assert.strictEqual(h2.tagName, 'H2')
+	assert.equal(h1.tagName, 'H1')
+	assert.equal(h2.tagName, 'H2')
 
 	root.render([b(), a()])
-	t.assert.strictEqual(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
+	assert.equal(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
 
-	t.assert.strictEqual(el.children[0], h2)
-	t.assert.strictEqual(el.children[1], h1)
+	assert.equal(el.children[0], h2)
+	assert.equal(el.children[1], h1)
 })
 
-test('implicit keyed lists preserve identity when reordered', (t: TestContext) => {
+test('implicit keyed lists preserve identity when reordered', () => {
 	const { root, el } = setup()
 
 	const items = [html`<h1>Item 1</h1>`, html`<h2>Item 2</h2>`]
 
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
+	assert.equal(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
 
 	const [h1, h2] = el.children
-	t.assert.strictEqual(h1.tagName, 'H1')
-	t.assert.strictEqual(h2.tagName, 'H2')
+	assert.equal(h1.tagName, 'H1')
+	assert.equal(h2.tagName, 'H2')
 	;[items[0], items[1]] = [items[1], items[0]]
 
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
-	t.assert.strictEqual(el.children[0].tagName, 'H2')
-	t.assert.strictEqual(el.children[1].tagName, 'H1')
+	assert.equal(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
+	assert.equal(el.children[0].tagName, 'H2')
+	assert.equal(el.children[1].tagName, 'H1')
 
-	t.assert.strictEqual(el.children[0], h2)
-	t.assert.strictEqual(el.children[1], h1)
+	assert.equal(el.children[0], h2)
+	assert.equal(el.children[1], h1)
 })
 
-test('implicit keyed lists with multiple elements preserve identity when resized', (t: TestContext) => {
+test('implicit keyed lists with multiple elements preserve identity when resized', () => {
 	const { root, el } = setup()
 
 	const items = [
@@ -263,74 +266,74 @@ test('implicit keyed lists with multiple elements preserve identity when resized
 	]
 
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML.replace(/\s+/g, ' '), '<h1>Item 1</h1> <h2>Item 2</h2> <p>Body content</p> ')
+	assert.equal(el.innerHTML.replace(/\s+/g, ' '), '<h1>Item 1</h1> <h2>Item 2</h2> <p>Body content</p> ')
 
 	const [h1, h2, p] = el.children
-	t.assert.strictEqual(h1.tagName, 'H1')
-	t.assert.strictEqual(h2.tagName, 'H2')
-	t.assert.strictEqual(p.tagName, 'P')
+	assert.equal(h1.tagName, 'H1')
+	assert.equal(h2.tagName, 'H2')
+	assert.equal(p.tagName, 'P')
 
 	// Swap
 	;[items[0], items[1]] = [items[1], items[0]]
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML.replace(/\s+/g, ' '), ' <h2>Item 2</h2> <p>Body content</p> <h1>Item 1</h1>')
-	t.assert.strictEqual(el.children[0].tagName, 'H2')
-	t.assert.strictEqual(el.children[1].tagName, 'P')
-	t.assert.strictEqual(el.children[2].tagName, 'H1')
+	assert.equal(el.innerHTML.replace(/\s+/g, ' '), ' <h2>Item 2</h2> <p>Body content</p> <h1>Item 1</h1>')
+	assert.equal(el.children[0].tagName, 'H2')
+	assert.equal(el.children[1].tagName, 'P')
+	assert.equal(el.children[2].tagName, 'H1')
 
-	t.assert.strictEqual(el.children[0], h2)
-	t.assert.strictEqual(el.children[1], p)
-	t.assert.strictEqual(el.children[2], h1)
+	assert.equal(el.children[0], h2)
+	assert.equal(el.children[1], p)
+	assert.equal(el.children[2], h1)
 
 	// Swap back
 	;[items[0], items[1]] = [items[1], items[0]]
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML.replace(/\s+/g, ' '), '<h1>Item 1</h1> <h2>Item 2</h2> <p>Body content</p> ')
-	t.assert.strictEqual(el.children[0].tagName, 'H1')
-	t.assert.strictEqual(el.children[1].tagName, 'H2')
-	t.assert.strictEqual(el.children[2].tagName, 'P')
-	t.assert.strictEqual(el.children[0], h1)
-	t.assert.strictEqual(el.children[1], h2)
-	t.assert.strictEqual(el.children[2], p)
+	assert.equal(el.innerHTML.replace(/\s+/g, ' '), '<h1>Item 1</h1> <h2>Item 2</h2> <p>Body content</p> ')
+	assert.equal(el.children[0].tagName, 'H1')
+	assert.equal(el.children[1].tagName, 'H2')
+	assert.equal(el.children[2].tagName, 'P')
+	assert.equal(el.children[0], h1)
+	assert.equal(el.children[1], h2)
+	assert.equal(el.children[2], p)
 })
 
-test('implicit keyed renderable lists preserve identity when reordered', (t: TestContext) => {
+test('implicit keyed renderable lists preserve identity when reordered', () => {
 	const { root, el } = setup()
 
 	const items = [{ render: () => html`<h1>Item 1</h1>` }, { render: () => html`<h2>Item 2</h2>` }]
 
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
+	assert.equal(el.innerHTML, '<h1>Item 1</h1><h2>Item 2</h2>')
 
 	const [h1, h2] = el.children
-	t.assert.strictEqual(h1.tagName, 'H1')
-	t.assert.strictEqual(h2.tagName, 'H2')
+	assert.equal(h1.tagName, 'H1')
+	assert.equal(h2.tagName, 'H2')
 	;[items[0], items[1]] = [items[1], items[0]]
 
 	root.render(items)
-	t.assert.strictEqual(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
-	t.assert.strictEqual(el.children[0].tagName, 'H2')
-	t.assert.strictEqual(el.children[1].tagName, 'H1')
+	assert.equal(el.innerHTML, '<h2>Item 2</h2><h1>Item 1</h1>')
+	assert.equal(el.children[0].tagName, 'H2')
+	assert.equal(el.children[1].tagName, 'H1')
 
-	t.assert.strictEqual(el.children[0], h2)
-	t.assert.strictEqual(el.children[1], h1)
+	assert.equal(el.children[0], h2)
+	assert.equal(el.children[1], h1)
 })
 
-test('many items can be reordered', (t: TestContext) => {
+test('many items can be reordered', () => {
 	const { root, el } = setup()
 
 	const items = Array.from({ length: 10 }, (_, i) => [html`<p>Item ${i}</p>`, `<p>Item ${i}</p>`])
 
 	root.render(items.map(([item]) => item))
-	t.assert.strictEqual(el.innerHTML, items.map(([, html]) => html).join(''))
+	assert.equal(el.innerHTML, items.map(([, html]) => html).join(''))
 
 	shuffle(items)
 
 	root.render(items.map(([item]) => item))
-	t.assert.strictEqual(el.innerHTML, items.map(([, html]) => html).join(''))
+	assert.equal(el.innerHTML, items.map(([, html]) => html).join(''))
 })
 
-test('keying something twice throws an error', { skip: process.env.NODE_ENV === 'production' }, (t: TestContext) => {
-	t.assert.doesNotThrow(() => keyed(html``, 1))
-	t.assert.throws(() => keyed(keyed(html``, 1), 1))
+dev_test('keying something twice throws an error', () => {
+	assert.doesNotThrow(() => keyed(html``, 1))
+	assert.throws(() => keyed(keyed(html``, 1), 1))
 })

--- a/src/client/tests/recursion.test.ts
+++ b/src/client/tests/recursion.test.ts
@@ -1,10 +1,11 @@
+import { test } from 'bun:test'
 import { html } from 'dhtml'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
 
 const DEPTH = 10
 
-test('basic recursion is handled correctly', (t: TestContext) => {
+test('basic recursion is handled correctly', () => {
 	const { root, el } = setup()
 
 	const app = {
@@ -15,10 +16,10 @@ test('basic recursion is handled correctly', (t: TestContext) => {
 		},
 	}
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, 'hello!')
+	assert.equal(el.innerHTML, 'hello!')
 })
 
-test('nested recursion is handled correctly', (t: TestContext) => {
+test('nested recursion is handled correctly', () => {
 	const { root, el } = setup()
 
 	const app = {
@@ -29,5 +30,5 @@ test('nested recursion is handled correctly', (t: TestContext) => {
 		},
 	}
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, '<span>'.repeat(DEPTH) + 'hello!' + '</span>'.repeat(DEPTH))
+	assert.equal(el.innerHTML, '<span>'.repeat(DEPTH) + 'hello!' + '</span>'.repeat(DEPTH))
 })

--- a/src/client/tests/renderable.test.ts
+++ b/src/client/tests/renderable.test.ts
@@ -1,9 +1,10 @@
+import { mock, test } from 'bun:test'
 import { html, type Renderable } from 'dhtml'
 import { getParentNode, invalidate, onMount, onUnmount } from 'dhtml/client'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 import { setup } from './setup.ts'
 
-test('renderables work correctly', async (t: TestContext) => {
+test('renderables work correctly', async () => {
 	const { root, el } = setup()
 
 	root.render(
@@ -13,7 +14,7 @@ test('renderables work correctly', async (t: TestContext) => {
 			},
 		}}`,
 	)
-	t.assert.strictEqual(el.innerHTML, '<h1>Hello, world!</h1>')
+	assert.equal(el.innerHTML, '<h1>Hello, world!</h1>')
 
 	const app = {
 		i: 0,
@@ -22,17 +23,17 @@ test('renderables work correctly', async (t: TestContext) => {
 		},
 	}
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, 'Count: 0')
+	assert.equal(el.innerHTML, 'Count: 0')
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, 'Count: 1')
+	assert.equal(el.innerHTML, 'Count: 1')
 	await invalidate(app)
-	t.assert.strictEqual(el.innerHTML, 'Count: 2')
+	assert.equal(el.innerHTML, 'Count: 2')
 	await invalidate(app)
-	t.assert.strictEqual(el.innerHTML, 'Count: 3')
-	t.assert.strictEqual(app.i, 4)
+	assert.equal(el.innerHTML, 'Count: 3')
+	assert.equal(app.i, 4)
 })
 
-test('renderables handle undefined correctly', (t: TestContext) => {
+test('renderables handle undefined correctly', () => {
 	const { root, el } = setup()
 
 	root.render({
@@ -40,10 +41,10 @@ test('renderables handle undefined correctly', (t: TestContext) => {
 		render() {},
 	})
 
-	t.assert.strictEqual(el.innerHTML, '')
+	assert.equal(el.innerHTML, '')
 })
 
-test('onMount calls in the right order', (t: TestContext) => {
+test('onMount calls in the right order', () => {
 	const { root, el } = setup()
 
 	const sequence: string[] = []
@@ -86,24 +87,24 @@ test('onMount calls in the right order', (t: TestContext) => {
 
 	outer.show = true
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, 'inner')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner render', 'inner mount', 'outer mount'])
+	assert.equal(el.innerHTML, 'inner')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner render', 'inner mount', 'outer mount'])
 	sequence.length = 0
 
 	outer.show = false
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, '')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner cleanup'])
+	assert.equal(el.innerHTML, '')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner cleanup'])
 	sequence.length = 0
 
 	outer.show = true
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, 'inner')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
+	assert.equal(el.innerHTML, 'inner')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
 	sequence.length = 0
 })
 
-test('onMount registers multiple callbacks', (t: TestContext) => {
+test('onMount registers multiple callbacks', () => {
 	const { root } = setup()
 
 	const sequence: string[] = []
@@ -125,14 +126,14 @@ test('onMount registers multiple callbacks', (t: TestContext) => {
 	}
 
 	root.render(app)
-	t.assert.deepStrictEqual(sequence, ['mount 1', 'mount 2'])
+	assert.deepStrictEqual(sequence, ['mount 1', 'mount 2'])
 	sequence.length = 0
 
 	root.render(null)
-	t.assert.deepStrictEqual(sequence, ['cleanup 1', 'cleanup 2'])
+	assert.deepStrictEqual(sequence, ['cleanup 1', 'cleanup 2'])
 })
 
-test('onMount registers a fixed callback once', (t: TestContext) => {
+test('onMount registers a fixed callback once', () => {
 	const { root } = setup()
 
 	const sequence: string[] = []
@@ -151,14 +152,14 @@ test('onMount registers a fixed callback once', (t: TestContext) => {
 	}
 
 	root.render(app)
-	t.assert.deepStrictEqual(sequence, ['mount'])
+	assert.deepStrictEqual(sequence, ['mount'])
 	sequence.length = 0
 
 	root.render(null)
-	t.assert.deepStrictEqual(sequence, ['cleanup'])
+	assert.deepStrictEqual(sequence, ['cleanup'])
 })
 
-test('onMount registers callbacks outside of render', (t: TestContext) => {
+test('onMount registers callbacks outside of render', () => {
 	const { root } = setup()
 
 	const sequence: string[] = []
@@ -175,24 +176,24 @@ test('onMount registers callbacks outside of render', (t: TestContext) => {
 		return () => sequence.push('cleanup')
 	})
 
-	t.assert.deepStrictEqual(sequence, [])
+	assert.deepStrictEqual(sequence, [])
 
 	root.render(app)
-	t.assert.deepStrictEqual(sequence, ['render', 'mount'])
+	assert.deepStrictEqual(sequence, ['render', 'mount'])
 	sequence.length = 0
 
 	root.render(null)
-	t.assert.deepStrictEqual(sequence, ['cleanup'])
+	assert.deepStrictEqual(sequence, ['cleanup'])
 })
 
-test('onMount can access the dom in callback', (t: TestContext) => {
+test('onMount can access the dom in callback', () => {
 	const { root } = setup()
 
 	const app = {
 		render() {
 			onMount(this, () => {
 				const parent = getParentNode(this) as Element
-				t.assert.ok(parent.firstElementChild instanceof HTMLParagraphElement)
+				assert(parent.firstElementChild instanceof HTMLParagraphElement)
 			})
 			return html`<p>Hello, world!</p>`
 		},
@@ -201,7 +202,7 @@ test('onMount can access the dom in callback', (t: TestContext) => {
 	root.render(app)
 })
 
-test('onMount works after render', (t: TestContext) => {
+test('onMount works after render', () => {
 	const { root } = setup()
 
 	const app = {
@@ -212,12 +213,12 @@ test('onMount works after render', (t: TestContext) => {
 
 	root.render(app)
 
-	const mounted = t.mock.fn()
+	const mounted = mock(() => {})
 	onMount(app, mounted)
-	t.assert.strictEqual(mounted.mock.callCount(), 1)
+	assert.equal(mounted.mock.calls.length, 1)
 })
 
-test('onUnmount deep works correctly', (t: TestContext) => {
+test('onUnmount deep works correctly', () => {
 	const { root, el } = setup()
 
 	const sequence: string[] = []
@@ -256,30 +257,30 @@ test('onUnmount deep works correctly', (t: TestContext) => {
 
 	outer.show = true
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, 'inner')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
+	assert.equal(el.innerHTML, 'inner')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
 	sequence.length = 0
 
 	outer.show = false
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, '')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
+	assert.equal(el.innerHTML, '')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
 	sequence.length = 0
 
 	outer.show = true
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, 'inner')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
+	assert.equal(el.innerHTML, 'inner')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
 	sequence.length = 0
 
 	outer.show = false
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, '')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
+	assert.equal(el.innerHTML, '')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
 	sequence.length = 0
 })
 
-test('onUnmount shallow works correctly', (t: TestContext) => {
+test('onUnmount shallow works correctly', () => {
 	const { root, el } = setup()
 
 	const sequence: string[] = []
@@ -317,30 +318,30 @@ test('onUnmount shallow works correctly', (t: TestContext) => {
 
 	outer.show = true
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, 'inner')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
+	assert.equal(el.innerHTML, 'inner')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
 	sequence.length = 0
 
 	outer.show = false
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, '')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
+	assert.equal(el.innerHTML, '')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
 	sequence.length = 0
 
 	outer.show = true
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, 'inner')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
+	assert.equal(el.innerHTML, 'inner')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner render'])
 	sequence.length = 0
 
 	outer.show = false
 	root.render(outer)
-	t.assert.strictEqual(el.innerHTML, '')
-	t.assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
+	assert.equal(el.innerHTML, '')
+	assert.deepStrictEqual(sequence, ['outer render', 'inner abort'])
 	sequence.length = 0
 })
 
-test('onUnmount works externally', async (t: TestContext) => {
+test('onUnmount works externally', async () => {
 	const { root, el } = setup()
 
 	const app = {
@@ -349,18 +350,18 @@ test('onUnmount works externally', async (t: TestContext) => {
 		},
 	}
 
-	const unmounted = t.mock.fn()
+	const unmounted = mock(() => {})
 	onUnmount(app, unmounted)
 
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, '<div>1</div><div>2</div><div>3</div>')
-	t.assert.strictEqual(unmounted.mock.callCount(), 0)
+	assert.equal(el.innerHTML, '<div>1</div><div>2</div><div>3</div>')
+	assert.equal(unmounted.mock.calls.length, 0)
 
 	root.render(null)
-	t.assert.strictEqual(unmounted.mock.callCount(), 1)
+	assert.equal(unmounted.mock.calls.length, 1)
 })
 
-test('getParentNode works externally', (t: TestContext) => {
+test('getParentNode works externally', () => {
 	const { root, el } = setup()
 
 	const app = {
@@ -370,11 +371,11 @@ test('getParentNode works externally', (t: TestContext) => {
 	}
 
 	root.render(app)
-	t.assert.strictEqual(el.innerHTML, '<div></div>')
-	t.assert.strictEqual(getParentNode(app), el)
+	assert.equal(el.innerHTML, '<div></div>')
+	assert.equal(getParentNode(app), el)
 })
 
-test('getParentNode works internally', (t: TestContext) => {
+test('getParentNode works internally', () => {
 	const { root, el } = setup()
 
 	root.render({
@@ -383,25 +384,25 @@ test('getParentNode works internally', (t: TestContext) => {
 		},
 	} satisfies Renderable)
 
-	t.assert.strictEqual(el.innerHTML, '<div>true</div>')
+	assert.equal(el.innerHTML, '<div>true</div>')
 })
 
-test('getParentNode handles nesting', (t: TestContext) => {
+test('getParentNode handles nesting', () => {
 	const { root, el } = setup()
 
 	const inner = {
 		render() {
 			const parent = getParentNode(this)
 
-			t.assert.ok(parent instanceof HTMLDivElement)
-			t.assert.strictEqual((parent as HTMLDivElement).outerHTML, '<div class="the-app"><!----></div>')
-			t.assert.strictEqual(parent.parentNode, el)
+			assert(parent instanceof HTMLDivElement)
+			assert.equal((parent as HTMLDivElement).outerHTML, '<div class="the-app"><!----></div>')
+			assert.equal(parent.parentNode, el)
 
 			return null
 		},
 	}
 
-	const spy = t.mock.fn(inner.render)
+	const spy = mock(inner.render)
 	inner.render = spy
 
 	root.render({
@@ -410,5 +411,5 @@ test('getParentNode handles nesting', (t: TestContext) => {
 		},
 	})
 
-	t.assert.strictEqual(spy.mock.callCount(), 1)
+	assert.equal(spy.mock.calls.length, 1)
 })

--- a/src/client/tests/setup.ts
+++ b/src/client/tests/setup.ts
@@ -1,9 +1,8 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator'
+import { afterEach } from 'bun:test'
 import { createRoot, type Root } from 'dhtml/client'
-import { afterEach } from 'node:test'
 
 GlobalRegistrator.register()
-globalThis.__DEV__ = process.env.NODE_ENV !== 'production'
 
 const roots: Root[] = []
 

--- a/src/server/tests/basic.test.ts
+++ b/src/server/tests/basic.test.ts
@@ -1,31 +1,32 @@
+import { test } from 'bun:test'
 import { html } from 'dhtml'
 import { renderToString } from 'dhtml/server'
-import test, { type TestContext } from 'node:test'
+import assert from 'node:assert/strict'
 
-globalThis.__DEV__ = process.env.NODE_ENV !== 'production'
+const dev_test = test.skipIf(!__DEV__)
 
-test('basic html renders correctly', (t: TestContext) => {
-	t.assert.strictEqual(renderToString(html`<h1>Hello, world!</h1>`), '<h1>Hello, world!</h1>')
+test('basic html renders correctly', () => {
+	assert.equal(renderToString(html`<h1>Hello, world!</h1>`), '<h1>Hello, world!</h1>')
 })
 
-test('inner content renders correctly', (t: TestContext) => {
-	t.assert.strictEqual(renderToString(html`<h1>${html`Inner content!`}</h1>`), '<h1>Inner content!</h1>')
+test('inner content renders correctly', () => {
+	assert.equal(renderToString(html`<h1>${html`Inner content!`}</h1>`), '<h1>Inner content!</h1>')
 })
 
-test('template with number renders correctly', (t: TestContext) => {
+test('template with number renders correctly', () => {
 	const template = (n: number) => html`<h1>Hello, ${n}!</h1>`
-	t.assert.strictEqual(renderToString(template(1)), '<h1>Hello, 1!</h1>')
-	t.assert.strictEqual(renderToString(template(2)), '<h1>Hello, 2!</h1>')
+	assert.equal(renderToString(template(1)), '<h1>Hello, 1!</h1>')
+	assert.equal(renderToString(template(2)), '<h1>Hello, 2!</h1>')
 })
 
-test('basic children render correctly', (t: TestContext) => {
-	t.assert.strictEqual(
+test('basic children render correctly', () => {
+	assert.equal(
 		renderToString(html`<span>${'This is a'}</span> ${html`test`} ${html`test`} ${html`test`}`),
 		'<span>This is a</span> test test test',
 	)
 })
 
-test('errors are thrown cleanly', (t: TestContext) => {
+test('errors are thrown cleanly', () => {
 	const oops = new Error('oops')
 	let thrown
 	try {
@@ -39,27 +40,23 @@ test('errors are thrown cleanly', (t: TestContext) => {
 	} catch (error) {
 		thrown = error
 	}
-	t.assert.strictEqual(thrown, oops)
+	assert.equal(thrown, oops)
 })
 
-test('invalid part placement raises error', { skip: process.env.NODE_ENV === 'production' }, (t: TestContext) => {
-	t.assert.throws(() => renderToString(html`<${'div'}>${'text'}</${'div'}>`))
+dev_test('invalid part placement raises error', () => {
+	assert.throws(() => renderToString(html`<${'div'}>${'text'}</${'div'}>`))
 })
 
-test('parts in comments do not throw', (t: TestContext) => {
+test('parts in comments do not throw', () => {
 	renderToString(html`<!-- ${'text'} -->`)
 })
 
-test(
-	'manually specifying internal template syntax throws',
-	{ skip: process.env.NODE_ENV === 'production' },
-	(t: TestContext) => {
-		t.assert.throws(() => {
-			renderToString(html`${1} dyn-$0$`)
-		})
-	},
-)
+dev_test('manually specifying internal template syntax throws', () => {
+	assert.throws(() => {
+		renderToString(html`${1} dyn-$0$`)
+	})
+})
 
-test('syntax close but not exact does not throw', (t: TestContext) => {
-	t.assert.strictEqual(renderToString(html`dyn-$${0}1$`), 'dyn-$01$')
+test('syntax close but not exact does not throw', () => {
+	assert.equal(renderToString(html`dyn-$${0}1$`), 'dyn-$01$')
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
 		"allowImportingTsExtensions": true,
 		"stripInternal": true,
 		"isolatedDeclarations": true,
-		"declaration": true
+		"declaration": true,
+		"types": ["bun-types"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
This is the 4th test runner I've used now, but it's way faster than `node:test` and I can always revert (note the use of `node:assert` and not `bun:test`s expect)