### PR TITLE
build: share a property mangling cache between files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,9 @@
 	"packages": {
 		"": {
 			"name": "dhtml",
+			"dev": true,
 			"devDependencies": {
 				"@happy-dom/global-registrator": "^17.4.4",
-				"@rollup/plugin-terser": "^0.4.4",
 				"@types/node": "^22.13.11",
 				"bun-types": "^1.2.5",
 				"dhtml": ".",
@@ -17,6 +17,7 @@
 				"magic-string": "^0.30.17",
 				"prettier": "^3.4.2",
 				"rolldown": "^1.0.0-beta.6",
+				"terser": "^5.39.0",
 				"typescript": "^5.7.2",
 				"zimmerframe": "^1.1.2"
 			}
@@ -314,314 +315,6 @@
 				"win32"
 			]
 		},
-		"node_modules/@rollup/plugin-terser": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
-			"integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"serialize-javascript": "^6.0.1",
-				"smob": "^1.0.0",
-				"terser": "^5.17.4"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^2.0.0||^3.0.0||^4.0.0"
-			},
-			"peerDependenciesMeta": {
-				"rollup": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-			"integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-			"integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-			"integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-			"integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-			"integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-			"integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-			"integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-			"integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-			"integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-			"integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-			"integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-			"integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-			"integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-			"integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-			"integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-			"integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-			"integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-			"integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true
-		},
-		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-			"integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true
-		},
 		"node_modules/@tybys/wasm-util": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -632,15 +325,6 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
-		},
-		"node_modules/@types/estree": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/@types/node": {
 			"version": "22.13.11",
@@ -673,7 +357,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.14.0",
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -685,6 +371,8 @@
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -701,6 +389,8 @@
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -831,22 +521,6 @@
 				}
 			}
 		},
-		"node_modules/fsevents": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
 		"node_modules/happy-dom": {
 			"version": "17.4.4",
 			"resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-17.4.4.tgz",
@@ -945,16 +619,6 @@
 				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/rolldown": {
 			"version": "1.0.0-beta.6",
 			"resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-beta.6.tgz",
@@ -992,47 +656,6 @@
 				}
 			}
 		},
-		"node_modules/rollup": {
-			"version": "4.34.8",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-			"integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/estree": "1.0.6"
-			},
-			"bin": {
-				"rollup": "dist/bin/rollup"
-			},
-			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=8.0.0"
-			},
-			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.34.8",
-				"@rollup/rollup-android-arm64": "4.34.8",
-				"@rollup/rollup-darwin-arm64": "4.34.8",
-				"@rollup/rollup-darwin-x64": "4.34.8",
-				"@rollup/rollup-freebsd-arm64": "4.34.8",
-				"@rollup/rollup-freebsd-x64": "4.34.8",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-				"@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-				"@rollup/rollup-linux-arm64-gnu": "4.34.8",
-				"@rollup/rollup-linux-arm64-musl": "4.34.8",
-				"@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-				"@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-				"@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-				"@rollup/rollup-linux-s390x-gnu": "4.34.8",
-				"@rollup/rollup-linux-x64-gnu": "4.34.8",
-				"@rollup/rollup-linux-x64-musl": "4.34.8",
-				"@rollup/rollup-win32-arm64-msvc": "4.34.8",
-				"@rollup/rollup-win32-ia32-msvc": "4.34.8",
-				"@rollup/rollup-win32-x64-msvc": "4.34.8",
-				"fsevents": "~2.3.2"
-			}
-		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -1046,46 +669,10 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
-			}
-		},
-		"node_modules/smob": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/smob/-/smob-1.5.0.tgz",
-			"integrity": "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -1094,6 +681,8 @@
 		},
 		"node_modules/source-map-support": {
 			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1102,7 +691,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.37.0",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+			"integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 	},
 	"devDependencies": {
 		"@happy-dom/global-registrator": "^17.4.4",
-		"@rollup/plugin-terser": "^0.4.4",
 		"@types/node": "^22.13.11",
 		"bun-types": "^1.2.5",
 		"dhtml": ".",
@@ -25,6 +24,7 @@
 		"magic-string": "^0.30.17",
 		"prettier": "^3.4.2",
 		"rolldown": "^1.0.0-beta.6",
+		"terser": "^5.39.0",
 		"typescript": "^5.7.2",
 		"zimmerframe": "^1.1.2"
 	},


### PR DESCRIPTION
by moving from rollup/plugin-terser to a tiny handrolled variant, because the official plugin runs terser in multiple isolated workers.