### PR TITLE
enable reentrant onMount handlers

### DIFF
--- a/examples/kanban/package-lock.json
+++ b/examples/kanban/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "kanban",
 			"dependencies": {
 				"@tombl/router": "npm:@jsr/tombl__router@^0.1.2",
-				"dhtml": "file:../..",
+				"dhtml": "file:../../dist",
 				"sqlocal": "^0.14.1"
 			},
 			"devDependencies": {
@@ -36,8 +36,7 @@
 			}
 		},
 		"../../dist": {
-			"name": "dhtml",
-			"extraneous": true
+			"name": "dhtml"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.0",
@@ -798,7 +797,7 @@
 			}
 		},
 		"node_modules/dhtml": {
-			"resolved": "../..",
+			"resolved": "../../dist",
 			"link": true
 		},
 		"node_modules/esbuild": {

--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@tombl/router": "npm:@jsr/tombl__router@^0.1.2",
-		"dhtml": "file:../..",
+		"dhtml": "file:../../dist",
 		"sqlocal": "^0.14.1"
 	}
 }

--- a/src/client/tests/renderable.test.ts
+++ b/src/client/tests/renderable.test.ts
@@ -373,6 +373,33 @@ test('onUnmount works externally', async () => {
 	assert.equal(unmounted.mock.calls.length, 1)
 })
 
+test('onMount works for repeated mounts', () => {
+	const { root, el } = setup()
+	let mounted: boolean | null = null
+
+	const app = {
+		render() {
+			return html`${mounted}`
+		},
+	}
+	onMount(app, () => {
+		mounted = true
+		return () => {
+			mounted = false
+		}
+	})
+
+	assert.equal(mounted, null)
+
+	for (let i = 0; i < 10; i++) {
+		root.render(app)
+		assert.equal(mounted, true)
+
+		root.render(null)
+		assert.equal(mounted, false)
+	}
+})
+
 test('getParentNode works externally', () => {
 	const { root, el } = setup()
 


### PR DESCRIPTION
previously, all `onMount` handlers were cleared after being called. this means that if the renderable is unmounted, then remounted, the mount handlers were not called again.

this changes things so the mount and unmount handlers are persisted and can now be called multiple times. 

because of reasons, the callbacks are no longer deduped, so it's even less safe than it was before to call `onMount` inside `.render()`. I have removed uses of this pattern from the tests, which has the fortunate side effect of making them clearer.