### PR TITLE
kanban/util/query: only suspend before we get the first value

### DIFF
--- a/examples/kanban/src/util/query.ts
+++ b/examples/kanban/src/util/query.ts
@@ -21,7 +21,8 @@ export function createQuery<T>(renderable: Renderable, fn: QueryFn<T>): Query<T>
 	}
 
 	function query() {
-		return suspend(renderable, promise)
+		if (value == null) return suspend(renderable, promise)
+		return value
 	}
 
 	query.revalidate = () => {


### PR DESCRIPTION
then we have a fallback to depend on, so use it