### PR TITLE
fix invalidating after hiding and showing a renderable

### DIFF
--- a/src/client/parts.ts
+++ b/src/client/parts.ts
@@ -65,7 +65,7 @@ export function create_child_part(parent_node: Node | Span, parent_span: Span, c
 			const renderable = value
 			const controller = get_controller(renderable)
 
-			controller._invalidate ??= () => {
+			controller._invalidate = () => {
 				assert(current_renderable === renderable, 'could not invalidate an outdated renderable')
 				update(renderable)
 			}


### PR DESCRIPTION
i can't reduce this to write a test, but the "loading..." flicker of the kanban example before https://github.com/tombl/dhtml/pull/70 would do something weird with the renderable identity, and I would simultaneously get a "renderable has not been rendered" error and a "this is not the current renderable" error.

this fixes it by always updating the `_invalidate` function on the controller, so the method doesn't hold onto a stale renderable.