### PR TITLE
fix html -> text update issue

### DIFF
--- a/src/client/parts.ts
+++ b/src/client/parts.ts
@@ -162,6 +162,7 @@ export function create_child_part(
 				entry._part(null)
 			}
 
+			old_value = undefined
 			return
 		} else if (entries) {
 			for (const entry of entries) entry._part(null)
@@ -250,7 +251,12 @@ export function create_child_part(
 
 			assert(template_parts)
 			for (const [idx, part] of template_parts) part(dynamics[idx])
-		} else if (!Object.is(old_value, value)) {
+
+			old_value = undefined
+			return
+		}
+
+		if (!Object.is(old_value, value)) {
 			// if we previously rendered a tree that might contain renderables,
 			// and the template has changed (or we're not even rendering a template anymore),
 			// we need to clear the old renderables.
@@ -264,9 +270,9 @@ export function create_child_part(
 				delete_contents(span)
 				if (value !== null) insert_node(span, value instanceof Node ? value : new Text('' + value))
 			}
-		}
 
-		old_value = value
+			old_value = value
+		}
 	}
 }
 

--- a/src/client/tests/basic.test.ts
+++ b/src/client/tests/basic.test.ts
@@ -183,3 +183,35 @@ test('syntax close but not exact does not throw', () => {
 
 	assert_eq(el.innerHTML, 'dyn-$01$')
 })
+
+{
+	const values = {
+		text: 'text',
+		number: 1234,
+		null: null,
+		iterable: ['iterable', 'of', 'things'],
+		html: html`html`,
+		html_element: html`<a href="#">element</a>`,
+		renderable: {
+			render() {
+				return 'hello'
+			},
+		},
+	}
+
+	for (const [a_name, a_value] of Object.entries(values)) {
+		for (const [b_name, b_value] of Object.entries(values)) {
+			test(`updating across value kinds: ${a_name} -> ${b_name}`, () => {
+				const { root, el } = setup()
+
+				root.render(a_value)
+				root.render(b_value)
+
+				const { root: root2, el: el2 } = setup()
+				root2.render(b_value)
+
+				assert_eq(el.innerHTML, el2.innerHTML)
+			})
+		}
+	}
+}


### PR DESCRIPTION
when `is_html(old_value)`, we would pass the conditional for the text update optimization.

now we clear `old_value` when rendering a non-text value so the conditional is never entered.