### PR TITLE
swap amaro for stripTypeScriptTypes from node:module

### DIFF
--- a/examples/ssr/main.ts
+++ b/examples/ssr/main.ts
@@ -1,9 +1,9 @@
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
-import { transformSync } from 'amaro'
 import { html } from 'dhtml'
 import { renderToString } from 'dhtml/server'
 import { Hono } from 'hono'
+import { stripTypeScriptTypes } from 'node:module'
 
 const app = new Hono()
 
@@ -11,7 +11,7 @@ app.use('/node_modules/*', serveStatic({ root: './' }))
 
 app.get('/app/:script{.+.ts}', async (c, next) => {
 	await next()
-	const { code } = transformSync(await c.res.text(), { mode: 'strip-only' })
+	const code = stripTypeScriptTypes(await c.res.text())
 	c.res = c.body(code)
 	c.res.headers.set('content-type', 'text/javascript')
 	c.res.headers.delete('content-length')

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"@hono/node-server": "^1.15.0",
-		"amaro": "^1.1.0",
+ 		"dhtml": "file:../../dist",
 		"hono": "^4.8.3"
 	},
 	"optionalDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       '@hono/node-server':
         specifier: ^1.15.0
         version: 1.19.1(hono@4.9.6)
-      amaro:
-        specifier: ^1.1.0
-        version: 1.1.2
       hono:
         specifier: ^4.8.3
         version: 4.9.6
@@ -147,9 +144,6 @@ importers:
       '@types/istanbul-reports':
         specifier: ^3.0.4
         version: 3.0.4
-      amaro:
-        specifier: ^1.1.6
-        version: 1.1.6
       ast-v8-to-istanbul:
         specifier: ^0.3.11
         version: 0.3.11
@@ -819,14 +813,6 @@ packages:
 
   alien-signals@3.1.2:
     resolution: {integrity: sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw==}
-
-  amaro@1.1.2:
-    resolution: {integrity: sha512-oJzgW3TS6b9tPOLFVFReAuSrg3QzFWs2TkMf/3fLjp77TKOL4EZpRR6ia9dO4g3R41J65D3J5ngCpFvRqk4yFQ==}
-    engines: {node: '>=22'}
-
-  amaro@1.1.6:
-    resolution: {integrity: sha512-9vi6GC+Mx1sdYgMVMk90mfU8e8JOZXa8dVBmpkn1hjkGGmlQew6FYop4+RXZinsWFRWmL6cuBmJgQYxx3+jCpA==}
-    engines: {node: '>=22'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1876,10 +1862,6 @@ snapshots:
   agent-base@7.1.4: {}
 
   alien-signals@3.1.2: {}
-
-  amaro@1.1.2: {}
-
-  amaro@1.1.6: {}
 
   ansi-regex@5.0.1: {}
 

--- a/scripts/test/browser-runtime.ts
+++ b/scripts/test/browser-runtime.ts
@@ -1,9 +1,9 @@
 import { serve } from '@hono/node-server'
 import { serveStatic } from '@hono/node-server/serve-static'
-import { transformSync } from 'amaro'
 import { Hono } from 'hono'
 import * as path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { stripTypeScriptTypes } from 'node:module'
 import * as puppeteer from 'puppeteer'
 import type { Runtime } from './main.ts'
 
@@ -44,7 +44,7 @@ export async function create_browser_runtime(options: BrowserRuntimeOptions = {}
 	app.use(async (c, next) => {
 		await next()
 		if (c.res.ok && c.req.path.endsWith('.ts')) {
-			const { code } = transformSync(await c.res.text(), { mode: 'strip-only' })
+			const code = stripTypeScriptTypes(await c.res.text())
 			c.res = c.body(code)
 			c.res.headers.set('content-type', 'text/javascript')
 			c.res.headers.delete('content-length')

--- a/scripts/test/package.json
+++ b/scripts/test/package.json
@@ -6,7 +6,6 @@
 		"@types/istanbul-lib-coverage": "^2.0.6",
 		"@types/istanbul-lib-report": "^3.0.3",
 		"@types/istanbul-reports": "^3.0.4",
-		"amaro": "^1.1.6",
 		"ast-v8-to-istanbul": "^0.3.11",
 		"birpc": "^4.0.0",
 		"devalue": "^5.6.2",


### PR DESCRIPTION
currently raises an experimental warning