### PR TITLE
examples/kanban: remove vite-tsconfig-paths

### DIFF
--- a/examples/kanban/package.json
+++ b/examples/kanban/package.json
@@ -10,12 +10,16 @@
 	},
 	"devDependencies": {
 		"typescript": "~5.8.3",
-		"vite": "^6.3.5",
-		"vite-tsconfig-paths": "^5.1.4"
+		"vite": "^6.3.5"
 	},
 	"dependencies": {
 		"@tombl/router": "npm:@jsr/tombl__router@^0.1.2",
 		"dhtml": "file:../../dist",
 		"sqlocal": "^0.14.1"
+	},
+	"imports": {
+		"#app": "./src/app.ts",
+		"#db": "./src/db/index.ts",
+		"#util/*": "./src/util/*"
 	}
 }

--- a/examples/kanban/src/db/boards.ts
+++ b/examples/kanban/src/db/boards.ts
@@ -1,4 +1,4 @@
-import type { App } from '~/app'
+import type { App } from '#app'
 import type { Board, ID } from '.'
 import { unwrap } from './database'
 

--- a/examples/kanban/src/db/cards.ts
+++ b/examples/kanban/src/db/cards.ts
@@ -1,4 +1,4 @@
-import type { App } from '~/app.ts'
+import type { App } from '#app'
 import { unwrap } from './database.ts'
 import type { Card, ID } from './index.ts'
 

--- a/examples/kanban/src/db/columns.ts
+++ b/examples/kanban/src/db/columns.ts
@@ -1,4 +1,4 @@
-import type { App } from '~/app.ts'
+import type { App } from '#app'
 import { unwrap } from './database.ts'
 import type { Column, ID } from './index.ts'
 

--- a/examples/kanban/src/pages/board/board.ts
+++ b/examples/kanban/src/pages/board/board.ts
@@ -1,8 +1,8 @@
+import type { App } from '#app'
+import * as db from '#db'
+import { type Query, createSubscribedQuery } from '#util/query.ts'
+import { createRecycler } from '#util/recycle.ts'
 import { html } from 'dhtml'
-import type { App } from '~/app'
-import * as db from '~/db'
-import { type Query, createSubscribedQuery } from '~/util/query'
-import { createRecycler } from '~/util/recycle'
 import { Column } from './column'
 import { text } from './text'
 

--- a/examples/kanban/src/pages/board/card.ts
+++ b/examples/kanban/src/pages/board/card.ts
@@ -1,7 +1,7 @@
+import type { App } from '#app'
+import * as db from '#db'
+import { type Query, createSubscribedQuery } from '#util/query.ts'
 import { html } from 'dhtml'
-import type { App } from '~/app'
-import * as db from '~/db'
-import { type Query, createSubscribedQuery } from '~/util/query'
 import { text } from './text'
 
 export class Card {

--- a/examples/kanban/src/pages/board/column.ts
+++ b/examples/kanban/src/pages/board/column.ts
@@ -1,8 +1,8 @@
+import type { App } from '#app'
+import * as db from '#db'
+import { type Query, createSubscribedQuery } from '#util/query.ts'
+import { createRecycler } from '#util/recycle.ts'
 import { html } from 'dhtml'
-import type { App } from '~/app'
-import * as db from '~/db'
-import { type Query, createSubscribedQuery } from '~/util/query'
-import { createRecycler } from '~/util/recycle'
 import { Card } from './card'
 import { text } from './text'
 

--- a/examples/kanban/src/pages/board/index.ts
+++ b/examples/kanban/src/pages/board/index.ts
@@ -1,5 +1,5 @@
-import type { PageContext } from '~/app'
-import type { ID } from '~/db'
+import type { PageContext } from '#app'
+import type { ID } from '#db'
 import { Board } from './board'
 
 export default function Page(context: PageContext, params: { id: string }) {

--- a/examples/kanban/src/pages/index.ts
+++ b/examples/kanban/src/pages/index.ts
@@ -1,7 +1,7 @@
+import type { App, PageContext } from '#app'
+import * as db from '#db'
+import { type Query, createSubscribedQuery } from '#util/query.ts'
 import { html } from 'dhtml'
-import type { App, PageContext } from '~/app'
-import * as db from '~/db'
-import { type Query, createSubscribedQuery } from '~/util/query'
 
 export default class Page {
 	#app: App

--- a/examples/kanban/src/util/recycle.ts
+++ b/examples/kanban/src/util/recycle.ts
@@ -1,4 +1,4 @@
-import type { ID } from '~/db'
+import type { ID } from '#db'
 
 export function createRecycler<T extends { id: ID }>(list: () => Promise<Array<{ id: ID }>>, construct: (id: ID) => T) {
 	return async (prev: T[] | null) => {

--- a/examples/kanban/tsconfig.json
+++ b/examples/kanban/tsconfig.json
@@ -19,11 +19,7 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noUncheckedSideEffectImports": true,
-
-		"paths": {
-			"~/*": ["./src/*"]
-		}
+		"noUncheckedSideEffectImports": true
 	},
 	"include": ["src"]
 }

--- a/examples/kanban/vite.config.js
+++ b/examples/kanban/vite.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig({
 	base: './',
@@ -9,7 +8,6 @@ export default defineConfig({
 	esbuild: { target: 'es2024' },
 	worker: { format: 'es' },
 	plugins: [
-		tsconfigPaths(),
 		{
 			name: 'configure-response-headers',
 			configureServer: server => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,7 @@
 			},
 			"devDependencies": {
 				"typescript": "~5.8.3",
-				"vite": "^6.3.5",
-				"vite-tsconfig-paths": "^5.1.4"
+				"vite": "^6.3.5"
 			}
 		},
 		"examples/kanban/node_modules/dhtml": {
@@ -1241,11 +1240,6 @@
 				"node": ">= 14"
 			}
 		},
-		"node_modules/globrex": {
-			"version": "0.1.2",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"license": "MIT",
@@ -2041,25 +2035,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/tsconfck": {
-			"version": "3.1.6",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"tsconfck": "bin/tsconfck.js"
-			},
-			"engines": {
-				"node": "^18 || >=20"
-			},
-			"peerDependencies": {
-				"typescript": "^5.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"license": "0BSD"
@@ -2154,24 +2129,6 @@
 					"optional": true
 				},
 				"yaml": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/vite-tsconfig-paths": {
-			"version": "5.1.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"globrex": "^0.1.2",
-				"tsconfck": "^3.0.3"
-			},
-			"peerDependencies": {
-				"vite": "*"
-			},
-			"peerDependenciesMeta": {
-				"vite": {
 					"optional": true
 				}
 			}


### PR DESCRIPTION
just use node's imports instead